### PR TITLE
[#172989102] Add notification queue settings in io-functions-app

### DIFF
--- a/prod/westeurope/internal/api/functions_app/function_app/terragrunt.hcl
+++ b/prod/westeurope/internal/api/functions_app/function_app/terragrunt.hcl
@@ -52,6 +52,18 @@ dependency "key_vault" {
   config_path = "../../../../common/key_vault"
 }
 
+dependency "notification_hub" {
+  config_path = "../../../../common/notification_hub"
+}
+
+dependency "notification_queue" {
+  config_path = "../../storage_notifications/queue_push-notifications"
+}
+
+dependency "notification_storage_account" {
+  config_path = "../../storage_notifications/account"
+}
+
 # Include all settings from the root terragrunt.hcl file
 include {
   path = find_in_parent_folders()
@@ -108,6 +120,11 @@ inputs = {
     FETCH_KEEPALIVE_TIMEOUT             = "60000"
   }
 
+  // Push notifications
+  AZURE_NH_HUB_NAME                       = dependency.notification_hub.outputs.name
+  NOTIFICATIONS_QUEUE_NAME                = dependency.notification_queue.outputs.name
+  NOTIFICATIONS_STORAGE_CONNECTION_STRING = dependency.notification_storage_account.outputs.primary_connection_string
+
   app_settings_secrets = {
     key_vault_id = dependency.key_vault.outputs.id
     map = {
@@ -116,6 +133,7 @@ inputs = {
       SENDGRID_API_KEY     = "common-SENDGRID-APIKEY"
       PUBLIC_API_KEY       = "apim-IO-SERVICE-KEY"
       SPID_LOGS_PUBLIC_KEY = "funcapp-KEY-SPIDLOGS-PUB"
+      AZURE_NH_ENDPOINT    = "common-AZURE-NH-ENDPOINT"
     }
   }
 

--- a/prod/westeurope/internal/api/functions_app/function_app/terragrunt.hcl
+++ b/prod/westeurope/internal/api/functions_app/function_app/terragrunt.hcl
@@ -118,12 +118,12 @@ inputs = {
     FETCH_KEEPALIVE_MAX_FREE_SOCKETS    = "10"
     FETCH_KEEPALIVE_FREE_SOCKET_TIMEOUT = "30000"
     FETCH_KEEPALIVE_TIMEOUT             = "60000"
-  }
 
-  // Push notifications
-  AZURE_NH_HUB_NAME                       = dependency.notification_hub.outputs.name
-  NOTIFICATIONS_QUEUE_NAME                = dependency.notification_queue.outputs.name
-  NOTIFICATIONS_STORAGE_CONNECTION_STRING = dependency.notification_storage_account.outputs.primary_connection_string
+    // Push notifications
+    AZURE_NH_HUB_NAME                       = dependency.notification_hub.outputs.name
+    NOTIFICATIONS_QUEUE_NAME                = dependency.notification_queue.outputs.name
+    NOTIFICATIONS_STORAGE_CONNECTION_STRING = dependency.notification_storage_account.outputs.primary_connection_string
+  }
 
   app_settings_secrets = {
     key_vault_id = dependency.key_vault.outputs.id


### PR DESCRIPTION
depends on https://github.com/pagopa/io-infrastructure-live-new/pull/161 (PR points there)

**Cannot be applied since it wants to reinstall the disabled sendgrid key** (cc @francescopersico)

I'm applying these settings manually, once merged we'll check again.
