### PR TITLE
[#172976853] Enable autoscaling in appgateway and apigateway

### DIFF
--- a/prod/westeurope/external/apigateway/application_gateway/terragrunt.hcl
+++ b/prod/westeurope/external/apigateway/application_gateway/terragrunt.hcl
@@ -152,5 +152,11 @@ inputs = {
 
     disabled_rule_groups = []
   }
+
+  autoscale_configuration = {
+    min_capacity = 2
+    max_capacity = 10
+  }
+
 }
 

--- a/prod/westeurope/external/apigateway/application_gateway/terragrunt.hcl
+++ b/prod/westeurope/external/apigateway/application_gateway/terragrunt.hcl
@@ -44,7 +44,7 @@ include {
 }
 
 terraform {
-  source = "git::git@github.com:pagopa/io-infrastructure-modules-new.git//azurerm_application_gateway?ref=v2.0.25"
+  source = "git::git@github.com:pagopa/io-infrastructure-modules-new.git//azurerm_application_gateway?ref=v2.0.26"
 }
 
 inputs = {

--- a/prod/westeurope/external/appgateway/application_gateway/terragrunt.hcl
+++ b/prod/westeurope/external/appgateway/application_gateway/terragrunt.hcl
@@ -40,7 +40,7 @@ include {
 }
 
 terraform {
-  source = "git::git@github.com:pagopa/io-infrastructure-modules-new.git//azurerm_application_gateway?ref=v2.0.25"
+  source = "git::git@github.com:pagopa/io-infrastructure-modules-new.git//azurerm_application_gateway?ref=v2.0.26"
 }
 
 inputs = {
@@ -134,5 +134,9 @@ inputs = {
       }
     ]
   }
-}
 
+  autoscale_configuration = {
+    min_capacity = 2
+    max_capacity = 10
+  }
+}


### PR DESCRIPTION
Due to this issue: https://github.com/terraform-providers/terraform-provider-azurerm/issues/6188
You need to run terrafrom with a custom azure provider.

And this should be the change in the plan:
```
resource "azurerm_application_gateway" "application_gateway" {
        enable_http2        = false
        id                  = "/subscriptions/****************/resourceGroups/io-p-rg-external/providers/Microsoft.Network/applicationGateways/io-p-ag-apigateway"
        location            = "westeurope"
        name                = "io-p-ag-apigateway"
        resource_group_name = "io-p-rg-external"
        tags                = {}
        zones               = []

      + autoscale_configuration {
          + max_capacity = 10
          + min_capacity = 2
        }

```