### PR TITLE
[#173352060] CDN endpoint for static assets

### DIFF
--- a/prod/westeurope/common/cdn/cdn_endpoint_assets/terragrunt.hcl
+++ b/prod/westeurope/common/cdn/cdn_endpoint_assets/terragrunt.hcl
@@ -28,7 +28,7 @@ inputs = {
 
   global_delivery_rule_cache_expiration_action = {
     behavior = "Override"
-    duration = "08:00:01"
+    duration = "08:00:00"
   }
 
   # Note: match_values = ["/services-data","/bonus"] works but the Azure portal displays only

--- a/prod/westeurope/common/cdn/cdn_endpoint_assets/terragrunt.hcl
+++ b/prod/westeurope/common/cdn/cdn_endpoint_assets/terragrunt.hcl
@@ -17,7 +17,7 @@ include {
 }
 
 terraform {
-  source = "git::git@github.com:pagopa/io-infrastructure-modules-new.git//azurerm_cdn_endpoint?ref=v2.0.25"
+  source = "git::git@github.com:pagopa/io-infrastructure-modules-new.git//azurerm_cdn_endpoint?ref=v2.0.31"
 }
 
 inputs = {
@@ -25,4 +25,41 @@ inputs = {
   resource_group_name = dependency.resource_group.outputs.resource_name
   profile_name        = dependency.cdn_profile.outputs.resource_name
   origin_host_name    = dependency.storage_account_assets.outputs.primary_web_host
+
+  global_delivery_rule_cache_expiration_action = [
+    {
+      behavior = "Override"
+      duration = "08:00:00"
+    }
+  ]
+
+  # Note: match_values = ["/services-data","/bonus"] works but the Azure portal displays only
+  # the first item for each rule generating confusion on the actual set of rules applied 
+  delivery_rule_url_path_condition_cache_expiration_action = [
+    {
+      name         = "servicesdatacache"
+      order        = 1
+      operator     = "BeginsWith"
+      match_values = ["/services-data"]
+      behavior     = "Override"
+      duration     = "00:15:00"
+    },
+    {
+      name         = "bonuscache"
+      order        = 2
+      operator     = "BeginsWith"
+      match_values = ["/bonus"]
+      behavior     = "Override"
+      duration     = "00:15:00"
+    },
+    {
+      name         = "statuscache"
+      order        = 3
+      operator     = "BeginsWith"
+      match_values = ["/status"]
+      behavior     = "Override"
+      duration     = "00:05:00"
+    }    
+  ]
+
 }

--- a/prod/westeurope/common/cdn/cdn_endpoint_assets/terragrunt.hcl
+++ b/prod/westeurope/common/cdn/cdn_endpoint_assets/terragrunt.hcl
@@ -26,12 +26,10 @@ inputs = {
   profile_name        = dependency.cdn_profile.outputs.resource_name
   origin_host_name    = dependency.storage_account_assets.outputs.primary_web_host
 
-  global_delivery_rule_cache_expiration_action = [
-    {
-      behavior = "Override"
-      duration = "08:00:00"
-    }
-  ]
+  global_delivery_rule_cache_expiration_action = {
+    behavior = "Override"
+    duration = "08:00:01"
+  }
 
   # Note: match_values = ["/services-data","/bonus"] works but the Azure portal displays only
   # the first item for each rule generating confusion on the actual set of rules applied 

--- a/prod/westeurope/common/cdn/cdn_endpoint_assets_cdn_custom_domain/terragrunt.hcl
+++ b/prod/westeurope/common/cdn/cdn_endpoint_assets_cdn_custom_domain/terragrunt.hcl
@@ -1,7 +1,3 @@
-# WARNING. This CDN endpoint custom domain is deprecated and is kept only for
-# backward compatibility in case some component depends on it. 
-# Please use the new custom domain "assets.cdn".
-
 dependency "cdn_profile" {
   config_path = "../cdn_profile"
 }
@@ -29,7 +25,7 @@ terraform {
 }
 
 inputs = {
-  name                = "assets"
+  name                = "assets.cdn"
   resource_group_name = dependency.resource_group.outputs.resource_name
   dns_zone = {
     name                = "io.italia.it"

--- a/prod/westeurope/common/cdn/cdn_endpoint_assets_cdn_custom_domain/terragrunt.hcl
+++ b/prod/westeurope/common/cdn/cdn_endpoint_assets_cdn_custom_domain/terragrunt.hcl
@@ -21,7 +21,7 @@ include {
 }
 
 terraform {
-  source = "git::git@github.com:pagopa/io-infrastructure-modules-new.git//azurerm_cdn_endpoint_custom_domain?ref=v2.0.25"
+  source = "git::git@github.com:pagopa/io-infrastructure-modules-new.git//azurerm_cdn_endpoint_custom_domain?ref=v2.0.31"
 }
 
 inputs = {

--- a/prod/westeurope/common/cdn/cdn_endpoint_assets_custom_domain/terragrunt.hcl
+++ b/prod/westeurope/common/cdn/cdn_endpoint_assets_custom_domain/terragrunt.hcl
@@ -25,7 +25,7 @@ terraform {
 }
 
 inputs = {
-  name                = "assets"
+  name                = "assets.cdn"
   resource_group_name = dependency.resource_group.outputs.resource_name
   dns_zone = {
     name                = "io.italia.it"


### PR DESCRIPTION
This PR contains the changes to configure the new CDN endpoint to serve static assets stored in a a $web container of a storage account.

In particular, the new CNAME `assets.cdn` in the DNS zone has been added to have the word "cdn" in the address and some delivery rules have beed defined to configure different caching expiration.   

The following URLs will need to be used to access the static resources when the whole solution is put in place: 
```
curl https://assets.cdn.io.italia.it/bonus/vacanze/bonuses_available.json -vvv
curl https://assets.cdn.io.italia.it/status/backend.json -vvv 
curl https://assets.cdn.io.italia.it/municipalities/A/0/A004.json -vvv 
curl https://assets.cdn.io.italia.it/services-data/visible-services.json -vvv  [TO DO]
...
...
```
all the files in the https://github.com/pagopa/io-services-metadata repository will be available via the CDN endpoint (i.e. they can be accessed in read mode as anonymous user without requiring authentication) without requiring to forward any request neither to the Backend API nor to the GitHub API.

**WARNING** This code assume that the required changes to the following module have been merged and released in the release **v2.0.31**: https://github.com/pagopa/io-infrastructure-live-new/blob/master/prod/westeurope/common/cdn/cdn_endpoint_assets/terragrunt.hcl.

See also other PRs:
- https://github.com/pagopa/io-infrastructure-modules-new/pull/143
- https://github.com/pagopa/io-services-metadata/pull/113