### PR TITLE
[#174649420] Update apim custom domain certificate

### DIFF
--- a/prod/westeurope/internal/api/apim/api_management/terragrunt.hcl
+++ b/prod/westeurope/internal/api/apim/api_management/terragrunt.hcl
@@ -42,7 +42,7 @@ include {
 }
 
 terraform {
-  source = "git::git@github.com:pagopa/io-infrastructure-modules-new.git//azurerm_api_management?ref=v2.0.38"
+  source = "git::git@github.com:pagopa/io-infrastructure-modules-new.git//azurerm_api_management?ref=v2.0.39"
 }
 
 inputs = {

--- a/prod/westeurope/internal/api/apim/api_management/terragrunt.hcl
+++ b/prod/westeurope/internal/api/apim/api_management/terragrunt.hcl
@@ -42,7 +42,7 @@ include {
 }
 
 terraform {
-  source = "git::git@github.com:pagopa/io-infrastructure-modules-new.git//azurerm_api_management?ref=v2.0.36"
+  source = "git::git@github.com:pagopa/io-infrastructure-modules-new.git//azurerm_api_management?ref=v2.0.38"
 }
 
 inputs = {

--- a/prod/westeurope/internal/api/apim/api_management/terragrunt.hcl
+++ b/prod/westeurope/internal/api/apim/api_management/terragrunt.hcl
@@ -42,7 +42,7 @@ include {
 }
 
 terraform {
-  source = "git::git@github.com:pagopa/io-infrastructure-modules-new.git//azurerm_api_management?ref=v2.0.25"
+  source = "git::git@github.com:pagopa/io-infrastructure-modules-new.git//azurerm_api_management?ref=v2.0.36"
 }
 
 inputs = {
@@ -81,7 +81,7 @@ inputs = {
 
   custom_domains = {
     key_vault_id     = dependency.key_vault.outputs.id
-    certificate_name = "io-italia-it"
+    certificate_name = "api-internal-io-italia-it"
     domains = [
       {
         name    = "api-internal.io.italia.it"

--- a/prod/westeurope/internal/api/apim/subnet/terragrunt.hcl
+++ b/prod/westeurope/internal/api/apim/subnet/terragrunt.hcl
@@ -9,7 +9,7 @@ include {
 }
 
 terraform {
-  source = "git::git@github.com:pagopa/io-infrastructure-modules-new.git//azurerm_subnet?ref=v2.0.25"
+  source = "git::git@github.com:pagopa/io-infrastructure-modules-new.git//azurerm_subnet?ref=v2.0.36"
 }
 
 inputs = {


### PR DESCRIPTION
- update custom domain certificate from `io-italia-it` to `api-internal-io-italia-it `
- update to module source to version v2.0.36 to avoid subnet `address_prefixies` deprecation

```
terragrunt plan

      ~ hostname_configuration {
          ~ proxy {
              ~ default_ssl_binding          = false -> true
              ~ host_name                    = "io-p-apim-api.azure-api.net" -> "api-internal.io.italia.it"
              + key_vault_id                 = "XXXXX"
                negotiate_client_certificate = false
            }
          - proxy {
              - default_ssl_binding          = true -> null
              - host_name                    = "api-internal.io.italia.it" -> null
              - key_vault_id                 = "XXXXX" -> null
              - negotiate_client_certificate = false -> null
            }
        }


  # azurerm_api_management_property.api_management_property["apigad-gad-client-certificate-verified-header"] will be updated in-place
  ~ resource "azurerm_api_management_property" "api_management_property" {
      ...
      + value               = "sensitive_value"
    }

  # azurerm_api_management_property.api_management_property["io-fn3-services-key"] will be created
  + resource "azurerm_api_management_property" "api_management_property" {
      ...
      + value               = "sensitive_value"
    }

  # azurerm_api_management_property.api_management_property["io-fn3-services-url"] will be created
  + resource "azurerm_api_management_property" "api_management_property" {
      ...
      + value               = "sensitive_value"
    }

  # azurerm_api_management_property.api_management_property["io-functions-admin-key"] will be updated in-place
  ~ resource "azurerm_api_management_property" "api_management_property" {
      ...
      + value               = "sensitive_value"
    }

  # azurerm_api_management_property.api_management_property["io-functions-admin-url"] will be updated in-place
  ~ resource "azurerm_api_management_property" "api_management_property" {
      ...
      + value               = "sensitive_value"
    }

  # azurerm_api_management_property.api_management_property["io-functions-bonusapi-key"] will be updated in-place
  ~ resource "azurerm_api_management_property" "api_management_property" {
      ...
      + value               = "sensitive_value"
    }

  # azurerm_api_management_property.api_management_property["io-functions-bonusapi-url"] will be updated in-place
  ~ resource "azurerm_api_management_property" "api_management_property" {
      ...
      + value               = "sensitive_value"
    }

  # azurerm_api_management_property.api_management_property["io-functions-public-key"] will be updated in-place
  ~ resource "azurerm_api_management_property" "api_management_property" {
      ...
      + value               = "sensitive_value"
    }

  # azurerm_api_management_property.api_management_property["io-functions-public-url"] will be updated in-place
  ~ resource "azurerm_api_management_property" "api_management_property" {
      ...
      + value               = "sensitive_value"
    }

  # azurerm_api_management_property.api_management_property["io-functions-test-key"] will be updated in-place
  ~ resource "azurerm_api_management_property" "api_management_property" {
      ...
      + value               = "sensitive_value"
    }

  # azurerm_api_management_property.api_management_property["io-functions-test-url"] will be updated in-place
  ~ resource "azurerm_api_management_property" "api_management_property" {
      ...
      + value               = "sensitive_value"
    }


Plan: 2 to add, 10 to change, 0 to destroy.

Warning: This resource has been superseded by `azurerm_api_management_named_value` to reflects changes in the API/SDK and will be removed in version 3.0 of the provider.
```