### PR TITLE
[#173830662] Fix arning azurerm_api_management_property deprecated

### DIFF
--- a/prod/westeurope/internal/api/apim/api_management/terragrunt.hcl
+++ b/prod/westeurope/internal/api/apim/api_management/terragrunt.hcl
@@ -42,7 +42,7 @@ include {
 }
 
 terraform {
-  source = "git::git@github.com:pagopa/io-infrastructure-modules-new.git//azurerm_api_management?ref=v2.0.39"
+  source = "git::git@github.com:pagopa/io-infrastructure-modules-new.git//azurerm_api_management?ref=v2.0.40"
 }
 
 inputs = {


### PR DESCRIPTION
Version of the module 2.0.40 includes this fix:
https://github.com/pagopa/io-infrastructure-modules-new/pull/147

I've already changed the state file running manually terraform import and terraform state rm.

```
No changes. Infrastructure is up-to-date.

This means that Terraform did not detect any differences between your
configuration and real physical resources that exist. As a result, no
actions need to be performed.
```