### PR TITLE
[#174824788 ] Add connection to subscriptions feed to fns-admin

### DIFF
--- a/prod/westeurope/internal/api/functions_admin_r3/function_app/terragrunt.hcl
+++ b/prod/westeurope/internal/api/functions_admin_r3/function_app/terragrunt.hcl
@@ -64,6 +64,10 @@ dependency "app_service_appbackend" {
   config_path = "../../../appbackend/app_service"
 }
 
+dependency "storage_table_subscriptionsfeedbyday" {
+  config_path = "../../storage/table_subscriptionsfeedbyday"
+}
+
 # Include all settings from the root terragrunt.hcl file
 include {
   path = find_in_parent_folders()
@@ -130,6 +134,9 @@ inputs = {
     "AzureWebJobs.UpdateVisibleServicesCache.Disabled" = "1"
 
     MAIL_FROM = "IO - l'app dei servizi pubblici <no-reply@io.italia.it>"
+
+    SUBSCRIPTIONS_FEED_TABLE          = dependency.storage_table_subscriptionsfeedbyday.outputs.name
+    SubscriptionFeedStorageConnection = dependency.storage_account.outputs.primary_connection_string
   }
 
   app_settings_secrets = {

--- a/prod/westeurope/internal/api/functions_admin_r3/function_app_slot_staging/terragrunt.hcl
+++ b/prod/westeurope/internal/api/functions_admin_r3/function_app_slot_staging/terragrunt.hcl
@@ -68,6 +68,9 @@ dependency "app_service_appbackend" {
   config_path = "../../../appbackend/app_service"
 }
 
+dependency "storage_table_subscriptionsfeedbyday" {
+  config_path = "../../storage/table_subscriptionsfeedbyday"
+}
 
 # Include all settings from the root terragrunt.hcl file
 include {
@@ -137,6 +140,9 @@ inputs = {
     SLOT_TASK_HUBNAME = "StagingTaskHub"
 
     MAIL_FROM = "IO - l'app dei servizi pubblici <no-reply@io.italia.it>"
+
+    SUBSCRIPTIONS_FEED_TABLE          = dependency.storage_table_subscriptionsfeedbyday.outputs.name
+    SubscriptionFeedStorageConnection = dependency.storage_account.outputs.primary_connection_string
   }
 
   app_settings_secrets = {


### PR DESCRIPTION
Allow `io-functions-admin` to write on Subscriptions Feed by introducing the following environment variables:

| Variable name                    | Description                                                                                      | type   |
|----------------------------------|--------------------------------------------------------------------------------------------------|--------|
| SubscriptionFeedStorageConnection| Storage connection string for subscription feed                                                  | string |
| SUBSCRIPTIONS_FEED_TABLE         | Table name for the Subscriptions Feed in the storage                                             | string |  

This PR blocks https://github.com/pagopa/io-functions-admin/pull/81