### PR TITLE
[#175225851] Add MAIL_FROM application settings on io-functions-services

### DIFF
--- a/prod/westeurope/internal/api/functions_services_r3/function_app/terragrunt.hcl
+++ b/prod/westeurope/internal/api/functions_services_r3/function_app/terragrunt.hcl
@@ -88,7 +88,10 @@ inputs = {
     MESSAGE_CONTAINER_NAME = dependency.storage_container_message-content.outputs.name
     // TODO: Rename to SUBSCRIPTIONSFEEDBYDAY_TABLE_NAME
     SUBSCRIPTIONS_FEED_TABLE = dependency.storage_table_subscriptionsfeedbyday.outputs.name
-    MAIL_FROM_DEFAULT        = "IO - l'app dei servizi pubblici <no-reply@io.italia.it>"
+    
+    MAIL_FROM         = "IO - l'app dei servizi pubblici <no-reply@io.italia.it>"
+    // we keep this while we wait for new app version to be deployed
+    MAIL_FROM_DEFAULT = "IO - l'app dei servizi pubblici <no-reply@io.italia.it>"
 
     // Keepalive fields are all optionals
     FETCH_KEEPALIVE_ENABLED             = "true"

--- a/prod/westeurope/internal/api/functions_services_r3/function_app_slot_staging/terragrunt.hcl
+++ b/prod/westeurope/internal/api/functions_services_r3/function_app_slot_staging/terragrunt.hcl
@@ -88,7 +88,10 @@ inputs = {
     MESSAGE_CONTAINER_NAME = dependency.storage_container_message-content.outputs.name
     // TODO: Rename to SUBSCRIPTIONSFEEDBYDAY_TABLE_NAME
     SUBSCRIPTIONS_FEED_TABLE = dependency.storage_table_subscriptionsfeedbyday.outputs.name
-    MAIL_FROM_DEFAULT        = "IO - l'app dei servizi pubblici <no-reply@io.italia.it>"
+    
+    MAIL_FROM         = "IO - l'app dei servizi pubblici <no-reply@io.italia.it>"
+    // we keep this while we wait for new app version to be deployed
+    MAIL_FROM_DEFAULT = "IO - l'app dei servizi pubblici <no-reply@io.italia.it>"
 
     // Keepalive fields are all optionals
     FETCH_KEEPALIVE_ENABLED             = "true"


### PR DESCRIPTION
As we are unifying utilities to send emails from our functions apps, we need to rename `MAIL_FROM_DEFAULT` app setting into `MAIL_FROM`. 

We keep them both as we didn't deploy the code yet, we then need to remove `MAIL_FROM_DEFAULT` once the related changes on `io-functions-services` land to production.