### PR TITLE
[#175395536] Allow uploadOrganizationLogo API on io-fn-services

### DIFF
--- a/prod/westeurope/internal/api/apim/api_management_api_services/swagger.json.tmpl
+++ b/prod/westeurope/internal/api/apim/api_management_api_services/swagger.json.tmpl
@@ -581,6 +581,55 @@
           }
         }
       }
+    },
+    "/organizations/{organization_fiscal_code}/logo": {
+      "parameters": [
+        {
+          "$ref": "#/parameters/OrganizationFiscalCode"
+        }
+      ],
+      "put": {
+        "summary": "Upload organization logo.",
+        "description": "Upsert a logo for an Organization.\n",
+        "operationId": "uploadOrganizationLogo",
+        "parameters": [
+          {
+            "name": "body",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/Logo"
+            },
+            "description": "A base64 string representation of the organization logo PNG image."
+          }
+        ],
+        "responses": {
+          "202": {
+            "description": "Logo uploaded."
+          },
+          "400": {
+            "description": "Invalid payload.",
+            "schema": {
+              "$ref": "#/definitions/ProblemJson"
+            }
+          },
+          "401": {
+            "description": "Unauthorized."
+          },
+          "403": {
+            "description": "Forbidden."
+          },
+          "429": {
+            "description": "Too many requests."
+          },
+          "500": {
+            "description": "The organization logo cannot be uploaded.",
+            "schema": {
+              "$ref": "#/definitions/ProblemJson"
+            }
+          }
+        }
+      }
     }
   },
   "definitions": {
@@ -1150,6 +1199,15 @@
       "description": "A date in the format YYYY-MM-DD.",
       "pattern": "[0-9]{4}-[0-9]{2}-[0-9]{2}",
       "x-example": "2019-09-15"
+    },
+    "OrganizationFiscalCode": {
+      "name": "organization_fiscal_code",
+      "in": "path",
+      "type": "string",
+      "required": true,
+      "description": "Organization fiscal code.",
+      "format": "OrganizationFiscalCode",
+      "x-import": "italia-ts-commons/lib/strings"
     }
   },
   "consumes": ["application/json"],


### PR DESCRIPTION
This PR contains an update of io-functions-services exposed API `uploadOrganizationLogo`