### PR TITLE
[#175126219] Disable autoswap on io-function-public

### DIFF
--- a/prod/westeurope/internal/api/functions_public_r3/function_app_slot_staging/terragrunt.hcl
+++ b/prod/westeurope/internal/api/functions_public_r3/function_app_slot_staging/terragrunt.hcl
@@ -61,8 +61,6 @@ inputs = {
 
   runtime_version = "~3"
 
-  auto_swap_slot_name = "production"
-
   application_insights_instrumentation_key = dependency.application_insights.outputs.instrumentation_key
 
   app_settings = {


### PR DESCRIPTION
Due to changes that will be introduced in [this PR](https://github.com/pagopa/io-functions-public/pull/21), the swap is going to be executed by the deploy pipeline.