### PR TITLE
[#176008623] Added new cdn endpoint "resources" and related storage account

### DIFF
--- a/prod/westeurope/common/cdn/cdn_endpoint_resources/terragrunt.hcl
+++ b/prod/westeurope/common/cdn/cdn_endpoint_resources/terragrunt.hcl
@@ -1,0 +1,28 @@
+dependency "cdn_profile" {
+  config_path = "../cdn_profile"
+}
+
+dependency "storage_account_static_assets_iopay" {
+  config_path = "../storage_account_resources"
+}
+
+# Common
+dependency "resource_group" {
+  config_path = "../../resource_group"
+}
+
+# Include all settings from the root terragrunt.hcl file
+include {
+  path = find_in_parent_folders()
+}
+
+terraform {
+  source = "git::git@github.com:pagopa/io-infrastructure-modules-new.git//azurerm_cdn_endpoint?ref=v2.1.15"
+}
+
+inputs = {
+  name                = "resources"
+  resource_group_name = dependency.resource_group.outputs.resource_name
+  profile_name        = dependency.cdn_profile.outputs.resource_name
+  origin_host_name    = dependency.storage_account_resources.outputs.primary_web_host
+}

--- a/prod/westeurope/common/cdn/cdn_endpoint_resources/terragrunt.hcl
+++ b/prod/westeurope/common/cdn/cdn_endpoint_resources/terragrunt.hcl
@@ -24,5 +24,5 @@ inputs = {
   name                = "resources"
   resource_group_name = dependency.resource_group.outputs.resource_name
   profile_name        = dependency.cdn_profile.outputs.resource_name
-  origin_host_name    = dependency.storage_account_resources.outputs.primary_web_host
+  origin_host_name    = dependency.storage_account_static_assets_iopay.outputs.primary_web_host
 }

--- a/prod/westeurope/common/cdn/storage_account_resources/terragrunt.hcl
+++ b/prod/westeurope/common/cdn/storage_account_resources/terragrunt.hcl
@@ -1,0 +1,24 @@
+dependency "resource_group" {
+  config_path = "../../resource_group"
+}
+
+# Include all settings from the root terragrunt.hcl file
+include {
+  path = find_in_parent_folders()
+}
+
+terraform {
+  source = "git::git@github.com:pagopa/io-infrastructure-modules-new.git//azurerm_storage_account_static_website?ref=v2.1.15"
+}
+
+inputs = {
+  name                     = "cdnresources"
+  resource_group_name      = dependency.resource_group.outputs.resource_name
+  account_tier             = "Standard"
+  account_replication_type = "GRS"
+  access_tier              = "Hot"
+  index_document           = "index.html"
+  error_404_document       = "404.html"
+
+  enable_versioning = true
+}


### PR DESCRIPTION
**Description**
This PR proposes to add a new endpoint to the cdn to serve static assets/resources. The endpoint is linked to the storage account `storage_account_resources` configured to serve static web files. Despite being deprecated, an endpoint `assets` is already in place in the infrastructure, so for the sake of simplicity in naming patterns, I chose the totally different name `resources`.

**Proposed changes**
- New cdn endpoint `resources`
- New storage account `storage_account_resources` to serve static web files

**How to test**
This PR is just a proposal. I haven't actually tested it