### PR TITLE
Tuning appbackends linux FETCH_KEEPALIVE_MAX_SOCKETS and sku_size

### DIFF
--- a/prod/westeurope/linux/appbackendl1/app_service/terragrunt.hcl
+++ b/prod/westeurope/linux/appbackendl1/app_service/terragrunt.hcl
@@ -103,7 +103,7 @@ inputs = {
   app_service_plan_info = {
     kind             = "Linux"
     sku_tier         = "PremiumV2"
-    sku_size         = "P3v2"
+    sku_size         = "P2v2"
     reserved         = true
     per_site_scaling = false
   }
@@ -130,7 +130,7 @@ inputs = {
     // FETCH_KEEPALIVE_SOCKET_ACTIVE_TTL should not exceed 120000 (app service socket timeout)
     FETCH_KEEPALIVE_SOCKET_ACTIVE_TTL = "110000"
     // (FETCH_KEEPALIVE_MAX_SOCKETS * number_of_node_processes) should not exceed 160 (max sockets per VM)
-    FETCH_KEEPALIVE_MAX_SOCKETS         = "40"
+    FETCH_KEEPALIVE_MAX_SOCKETS         = "80"
     FETCH_KEEPALIVE_MAX_FREE_SOCKETS    = "10"
     FETCH_KEEPALIVE_FREE_SOCKET_TIMEOUT = "30000"
     FETCH_KEEPALIVE_TIMEOUT             = "60000"

--- a/prod/westeurope/linux/appbackendl1/app_service_slot_staging/terragrunt.hcl
+++ b/prod/westeurope/linux/appbackendl1/app_service_slot_staging/terragrunt.hcl
@@ -122,7 +122,7 @@ inputs = {
     // FETCH_KEEPALIVE_SOCKET_ACTIVE_TTL should not exceed 120000 (app service socket timeout)
     FETCH_KEEPALIVE_SOCKET_ACTIVE_TTL = "110000"
     // (FETCH_KEEPALIVE_MAX_SOCKETS * number_of_node_processes) should not exceed 160 (max sockets per VM)
-    FETCH_KEEPALIVE_MAX_SOCKETS         = "40"
+    FETCH_KEEPALIVE_MAX_SOCKETS         = "80"
     FETCH_KEEPALIVE_MAX_FREE_SOCKETS    = "10"
     FETCH_KEEPALIVE_FREE_SOCKET_TIMEOUT = "30000"
     FETCH_KEEPALIVE_TIMEOUT             = "60000"

--- a/prod/westeurope/linux/appbackendl2/app_service/terragrunt.hcl
+++ b/prod/westeurope/linux/appbackendl2/app_service/terragrunt.hcl
@@ -103,7 +103,7 @@ inputs = {
   app_service_plan_info = {
     kind             = "Linux"
     sku_tier         = "PremiumV2"
-    sku_size         = "P3v2"
+    sku_size         = "P2v2"
     reserved         = true
     per_site_scaling = false
   }
@@ -130,7 +130,7 @@ inputs = {
     // FETCH_KEEPALIVE_SOCKET_ACTIVE_TTL should not exceed 120000 (app service socket timeout)
     FETCH_KEEPALIVE_SOCKET_ACTIVE_TTL = "110000"
     // (FETCH_KEEPALIVE_MAX_SOCKETS * number_of_node_processes) should not exceed 160 (max sockets per VM)
-    FETCH_KEEPALIVE_MAX_SOCKETS         = "40"
+    FETCH_KEEPALIVE_MAX_SOCKETS         = "80"
     FETCH_KEEPALIVE_MAX_FREE_SOCKETS    = "10"
     FETCH_KEEPALIVE_FREE_SOCKET_TIMEOUT = "30000"
     FETCH_KEEPALIVE_TIMEOUT             = "60000"

--- a/prod/westeurope/linux/appbackendl2/app_service_slot_staging/terragrunt.hcl
+++ b/prod/westeurope/linux/appbackendl2/app_service_slot_staging/terragrunt.hcl
@@ -122,7 +122,7 @@ inputs = {
     // FETCH_KEEPALIVE_SOCKET_ACTIVE_TTL should not exceed 120000 (app service socket timeout)
     FETCH_KEEPALIVE_SOCKET_ACTIVE_TTL = "110000"
     // (FETCH_KEEPALIVE_MAX_SOCKETS * number_of_node_processes) should not exceed 160 (max sockets per VM)
-    FETCH_KEEPALIVE_MAX_SOCKETS         = "40"
+    FETCH_KEEPALIVE_MAX_SOCKETS         = "80"
     FETCH_KEEPALIVE_MAX_FREE_SOCKETS    = "10"
     FETCH_KEEPALIVE_FREE_SOCKET_TIMEOUT = "30000"
     FETCH_KEEPALIVE_TIMEOUT             = "60000"


### PR DESCRIPTION
```
sku_size = P2v2
FETCH_KEEPALIVE_MAX_SOCKETS = 80
```
only on appbackendl1 and appbackendl2

appbackendli is in production and change this settings will restart the vm machines