### PR TITLE
[#176257846] Add environment variable for Bonus Vacanze request limit

### DIFF
--- a/prod/westeurope/linux/appbackendl1/app_service/terragrunt.hcl
+++ b/prod/westeurope/linux/appbackendl1/app_service/terragrunt.hcl
@@ -175,6 +175,9 @@ inputs = {
     PAGOPA_API_URL_TEST = "https://${dependency.app_service_pagopaproxytest.outputs.default_site_hostname}"
     PAGOPA_BASE_PATH    = "/pagopa/api/v1"
 
+    // BONUS VACANZE
+    BONUS_REQUEST_LIMIT_DATE =  "2020-12-31T22:59:59Z"
+
     // MYPORTAL
     MYPORTAL_BASE_PATH = "/myportal/api/v1"
 

--- a/prod/westeurope/linux/appbackendl1/app_service_slot_staging/terragrunt.hcl
+++ b/prod/westeurope/linux/appbackendl1/app_service_slot_staging/terragrunt.hcl
@@ -168,6 +168,9 @@ inputs = {
     PAGOPA_API_URL_TEST = "https://${dependency.app_service_pagopaproxytest.outputs.default_site_hostname}"
     PAGOPA_BASE_PATH    = "/pagopa/api/v1"
 
+    // BONUS VACANZE
+    BONUS_REQUEST_LIMIT_DATE =  "2020-12-31T22:59:59Z"
+
     // MYPORTAL
     MYPORTAL_BASE_PATH = "/myportal/api/v1"
 

--- a/prod/westeurope/linux/appbackendl2/app_service/terragrunt.hcl
+++ b/prod/westeurope/linux/appbackendl2/app_service/terragrunt.hcl
@@ -175,6 +175,9 @@ inputs = {
     PAGOPA_API_URL_TEST = "https://${dependency.app_service_pagopaproxytest.outputs.default_site_hostname}"
     PAGOPA_BASE_PATH    = "/pagopa/api/v1"
 
+    // BONUS VACANZE
+    BONUS_REQUEST_LIMIT_DATE =  "2020-12-31T22:59:59Z"
+
     // MYPORTAL
     MYPORTAL_BASE_PATH = "/myportal/api/v1"
 

--- a/prod/westeurope/linux/appbackendl2/app_service_slot_staging/terragrunt.hcl
+++ b/prod/westeurope/linux/appbackendl2/app_service_slot_staging/terragrunt.hcl
@@ -168,6 +168,9 @@ inputs = {
     PAGOPA_API_URL_TEST = "https://${dependency.app_service_pagopaproxytest.outputs.default_site_hostname}"
     PAGOPA_BASE_PATH    = "/pagopa/api/v1"
 
+    // BONUS VACANZE
+    BONUS_REQUEST_LIMIT_DATE =  "2020-12-31T22:59:59Z"
+
     // MYPORTAL
     MYPORTAL_BASE_PATH = "/myportal/api/v1"
 

--- a/prod/westeurope/linux/appbackendli/app_service/terragrunt.hcl
+++ b/prod/westeurope/linux/appbackendli/app_service/terragrunt.hcl
@@ -175,6 +175,9 @@ inputs = {
     PAGOPA_API_URL_TEST = "https://${dependency.app_service_pagopaproxytest.outputs.default_site_hostname}"
     PAGOPA_BASE_PATH    = "/pagopa/api/v1"
 
+    // BONUS VACANZE
+    BONUS_REQUEST_LIMIT_DATE =  "2020-12-31T22:59:59Z"
+
     // MYPORTAL
     MYPORTAL_BASE_PATH = "/myportal/api/v1"
 

--- a/prod/westeurope/linux/appbackendli/app_service_slot_staging/terragrunt.hcl
+++ b/prod/westeurope/linux/appbackendli/app_service_slot_staging/terragrunt.hcl
@@ -168,6 +168,9 @@ inputs = {
     PAGOPA_API_URL_TEST = "https://${dependency.app_service_pagopaproxytest.outputs.default_site_hostname}"
     PAGOPA_BASE_PATH    = "/pagopa/api/v1"
 
+    // BONUS VACANZE
+    BONUS_REQUEST_LIMIT_DATE =  "2020-12-31T22:59:59Z"
+
     // MYPORTAL
     MYPORTAL_BASE_PATH = "/myportal/api/v1"
 


### PR DESCRIPTION
From 1st of January 2021 users aren't allowed to request a new Bonus Vacanze. 

The `BONUS_REQUEST_LIMIT_DATE` variable is introduced, containing an ISO string date of the last second the service would be available (UTC).