### PR TITLE
[#176140405] fix content type name `io-pay-portal`

### DIFF
--- a/prod/westeurope/internal/api/apim/api_management_api_io_payportal/policy.xml
+++ b/prod/westeurope/internal/api/apim/api_management_api_io_payportal/policy.xml
@@ -16,7 +16,7 @@
         <method>GET</method>
       </allowed-methods>
       <allowed-headers>
-        <header>contentType</header>
+        <header>Content-Type</header>
       </allowed-headers>
     </cors>
   </inbound>


### PR DESCRIPTION
### Description

The purpose of this PR is to fix the content type name allow set into apim of `io-pay-portal`

### Proposed changes

Switch from `contentType` to `Content-Type` see also [here](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Type)