### PR TITLE
[#176738538] Allow Azure DevOps subnet for appbackend instances, remove BONUS_REQUEST_LIMIT_DATE, setted valid API_URL

### DIFF
--- a/prod/westeurope/linux/appbackendl1/app_service/terragrunt.hcl
+++ b/prod/westeurope/linux/appbackendl1/app_service/terragrunt.hcl
@@ -193,7 +193,6 @@ inputs = {
 
     // Feature flags
     FF_BONUS_ENABLED         = 1
-    BONUS_REQUEST_LIMIT_DATE = "2020-12-31T22:59:59Z"
 
     TEST_LOGIN_FISCAL_CODES = "AAAAAA00A00A000B"
 

--- a/prod/westeurope/linux/appbackendl1/app_service_slot_staging/terragrunt.hcl
+++ b/prod/westeurope/linux/appbackendl1/app_service_slot_staging/terragrunt.hcl
@@ -7,7 +7,7 @@ dependency "subnet" {
 }
 
 dependency "subnet_azure_devops" {
-  config_path = "../../common/subnet_azure_devops"
+  config_path = "../../../common/subnet_azure_devops"
 }
 
 # Internal

--- a/prod/westeurope/linux/appbackendl1/app_service_slot_staging/terragrunt.hcl
+++ b/prod/westeurope/linux/appbackendl1/app_service_slot_staging/terragrunt.hcl
@@ -7,7 +7,7 @@ dependency "subnet" {
 }
 
 dependency "subnet_azure_devops" {
-  config_path = "../../../../common/subnet_azure_devops"
+  config_path = "../../common/subnet_azure_devops"
 }
 
 # Internal

--- a/prod/westeurope/linux/appbackendl1/app_service_slot_staging/terragrunt.hcl
+++ b/prod/westeurope/linux/appbackendl1/app_service_slot_staging/terragrunt.hcl
@@ -6,6 +6,10 @@ dependency "subnet" {
   config_path = "../subnet"
 }
 
+dependency "subnet_azure_devops" {
+  config_path = "../../../../common/subnet_azure_devops"
+}
+
 # Internal
 dependency "resource_group" {
   config_path = "../../resource_group"
@@ -233,6 +237,7 @@ inputs = {
     dependency.subnet_appgateway.outputs.id,
     dependency.subnet_fn3services.outputs.id,
     dependency.subnet_funcadmin_r3.outputs.id,
+    dependency.subnet_azure_devops.outputs.id,
   ]
 
   subnet_id = dependency.subnet.outputs.id

--- a/prod/westeurope/linux/appbackendl1/app_service_slot_staging/terragrunt.hcl
+++ b/prod/westeurope/linux/appbackendl1/app_service_slot_staging/terragrunt.hcl
@@ -190,7 +190,6 @@ inputs = {
 
     // Feature flags
     FF_BONUS_ENABLED         = 1
-    BONUS_REQUEST_LIMIT_DATE = "2020-12-31T22:59:59Z"
 
     TEST_LOGIN_FISCAL_CODES = "AAAAAA00A00A000B"
 

--- a/prod/westeurope/linux/appbackendl2/app_service/terragrunt.hcl
+++ b/prod/westeurope/linux/appbackendl2/app_service/terragrunt.hcl
@@ -193,7 +193,6 @@ inputs = {
 
     // Feature flags
     FF_BONUS_ENABLED         = 1
-    BONUS_REQUEST_LIMIT_DATE = "2020-12-31T22:59:59Z"
 
     TEST_LOGIN_FISCAL_CODES = "AAAAAA00A00A000B"
 

--- a/prod/westeurope/linux/appbackendl2/app_service_slot_staging/terragrunt.hcl
+++ b/prod/westeurope/linux/appbackendl2/app_service_slot_staging/terragrunt.hcl
@@ -7,7 +7,7 @@ dependency "subnet" {
 }
 
 dependency "subnet_azure_devops" {
-  config_path = "../../common/subnet_azure_devops"
+  config_path = "../../../common/subnet_azure_devops"
 }
 
 # Internal

--- a/prod/westeurope/linux/appbackendl2/app_service_slot_staging/terragrunt.hcl
+++ b/prod/westeurope/linux/appbackendl2/app_service_slot_staging/terragrunt.hcl
@@ -7,7 +7,7 @@ dependency "subnet" {
 }
 
 dependency "subnet_azure_devops" {
-  config_path = "../../../../common/subnet_azure_devops"
+  config_path = "../../common/subnet_azure_devops"
 }
 
 # Internal

--- a/prod/westeurope/linux/appbackendl2/app_service_slot_staging/terragrunt.hcl
+++ b/prod/westeurope/linux/appbackendl2/app_service_slot_staging/terragrunt.hcl
@@ -6,6 +6,10 @@ dependency "subnet" {
   config_path = "../subnet"
 }
 
+dependency "subnet_azure_devops" {
+  config_path = "../../../../common/subnet_azure_devops"
+}
+
 # Internal
 dependency "resource_group" {
   config_path = "../../resource_group"
@@ -233,6 +237,7 @@ inputs = {
     dependency.subnet_appgateway.outputs.id,
     dependency.subnet_fn3services.outputs.id,
     dependency.subnet_funcadmin_r3.outputs.id,
+    dependency.subnet_azure_devops.outputs.id,
   ]
 
   subnet_id = dependency.subnet.outputs.id

--- a/prod/westeurope/linux/appbackendl2/app_service_slot_staging/terragrunt.hcl
+++ b/prod/westeurope/linux/appbackendl2/app_service_slot_staging/terragrunt.hcl
@@ -190,7 +190,6 @@ inputs = {
 
     // Feature flags
     FF_BONUS_ENABLED         = 1
-    BONUS_REQUEST_LIMIT_DATE = "2020-12-31T22:59:59Z"
 
     TEST_LOGIN_FISCAL_CODES = "AAAAAA00A00A000B"
 

--- a/prod/westeurope/linux/appbackendli/app_service/terragrunt.hcl
+++ b/prod/westeurope/linux/appbackendli/app_service/terragrunt.hcl
@@ -12,6 +12,11 @@ dependency "functions_bonus" {
   config_path = "../../../internal/api/functions_bonus/function_app"
 }
 
+# App Backend Api
+dependency "functions_app1_r3" {
+  config_path = "../../../functions_app1/functions_app1_r3/function_app"
+}
+
 # Push notifications origin
 dependency "subnet_fn3services" {
   config_path = "../../../internal/api/functions_services_r3/subnet"
@@ -147,7 +152,8 @@ inputs = {
     TOKEN_DURATION_IN_SECONDS = "2592000"
 
     // FUNCTIONS
-    API_URL       = "NONE"
+    // this function shouldn't be called anymore by the appbackendli.
+    API_URL       = "http://${dependency.functions_app1_r3.outputs.default_hostname}/api/v1"
     BONUS_API_URL = "http://${dependency.functions_bonus.outputs.default_hostname}/api/v1"
 
     // EXPOSED API
@@ -187,8 +193,7 @@ inputs = {
     USERS_LOGIN_QUEUE_NAME                = dependency.storage_queue_users_login.outputs.name
 
     // Feature flags
-    FF_BONUS_ENABLED         = 1
-    BONUS_REQUEST_LIMIT_DATE = "2020-12-31T22:59:59Z"
+    FF_BONUS_ENABLED = 1
 
     TEST_LOGIN_FISCAL_CODES = "AAAAAA00A00A000B"
 

--- a/prod/westeurope/linux/appbackendli/app_service_slot_staging/terragrunt.hcl
+++ b/prod/westeurope/linux/appbackendli/app_service_slot_staging/terragrunt.hcl
@@ -7,7 +7,7 @@ dependency "subnet" {
 }
 
 dependency "subnet_azure_devops" {
-  config_path = "../../common/subnet_azure_devops"
+  config_path = "../../../common/subnet_azure_devops"
 }
 
 # Internal

--- a/prod/westeurope/linux/appbackendli/app_service_slot_staging/terragrunt.hcl
+++ b/prod/westeurope/linux/appbackendli/app_service_slot_staging/terragrunt.hcl
@@ -6,6 +6,10 @@ dependency "subnet" {
   config_path = "../subnet"
 }
 
+dependency "subnet_azure_devops" {
+  config_path = "../../../../common/subnet_azure_devops"
+}
+
 # Internal
 dependency "resource_group" {
   config_path = "../../resource_group"
@@ -228,6 +232,7 @@ inputs = {
     dependency.subnet_appgateway.outputs.id,
     dependency.subnet_fn3services.outputs.id,
     dependency.subnet_funcadmin_r3.outputs.id,
+    dependency.subnet_azure_devops.outputs.id,
   ]
 
   subnet_id = dependency.subnet.outputs.id

--- a/prod/westeurope/linux/appbackendli/app_service_slot_staging/terragrunt.hcl
+++ b/prod/westeurope/linux/appbackendli/app_service_slot_staging/terragrunt.hcl
@@ -20,6 +20,11 @@ dependency "functions_bonus" {
   config_path = "../../../internal/api/functions_bonus/function_app"
 }
 
+# App Backend Api
+dependency "functions_app1_r3" {
+  config_path = "../../../functions_app1/functions_app1_r3/function_app"
+}
+
 # Push notifications origin
 dependency "subnet_fn3services" {
   config_path = "../../../internal/api/functions_services_r3/subnet"
@@ -144,7 +149,8 @@ inputs = {
     TOKEN_DURATION_IN_SECONDS = "2592000"
 
     // FUNCTIONS
-    API_URL       = "NONE"
+    // this function shouldn't be called anymore by the appbackendli.
+    API_URL       = "http://${dependency.functions_app1_r3.outputs.default_hostname}/api/v1"
     BONUS_API_URL = "http://${dependency.functions_bonus.outputs.default_hostname}/api/v1"
 
     // EXPOSED API
@@ -184,8 +190,7 @@ inputs = {
     USERS_LOGIN_QUEUE_NAME                = dependency.storage_queue_users_login.outputs.name
 
     // Feature flags
-    FF_BONUS_ENABLED         = 1
-    BONUS_REQUEST_LIMIT_DATE = "2020-12-31T22:59:59Z"
+    FF_BONUS_ENABLED = 1
 
     TEST_LOGIN_FISCAL_CODES = "AAAAAA00A00A000B"
 

--- a/prod/westeurope/linux/appbackendli/app_service_slot_staging/terragrunt.hcl
+++ b/prod/westeurope/linux/appbackendli/app_service_slot_staging/terragrunt.hcl
@@ -7,7 +7,7 @@ dependency "subnet" {
 }
 
 dependency "subnet_azure_devops" {
-  config_path = "../../../../common/subnet_azure_devops"
+  config_path = "../../common/subnet_azure_devops"
 }
 
 # Internal


### PR DESCRIPTION
These changes are needed in order to allow the deploy pipeline to reach the `/info` endpoint for each of the three app services.

