### PR TITLE
[#175897066] Allow azure devops vnet for CGN

### DIFF
--- a/prod/westeurope/cgn/function_cgn/function_app_slot_staging/terragrunt.hcl
+++ b/prod/westeurope/cgn/function_cgn/function_app_slot_staging/terragrunt.hcl
@@ -7,7 +7,7 @@ dependency "subnet" {
 }
 
 dependency "subnet_azure_devops" {
-  config_path = "../common/subnet_azure_devops"
+  config_path = "../../../common/subnet_azure_devops"
 }
 
 # cgn

--- a/prod/westeurope/cgn/function_cgn/function_app_slot_staging/terragrunt.hcl
+++ b/prod/westeurope/cgn/function_cgn/function_app_slot_staging/terragrunt.hcl
@@ -6,6 +6,10 @@ dependency "subnet" {
   config_path = "../subnet"
 }
 
+dependency "subnet_azure_devops" {
+  config_path = "../common/subnet_azure_devops"
+}
+
 # cgn
 dependency "resource_group" {
   config_path = "../../resource_group"
@@ -106,6 +110,7 @@ inputs = {
 
   allowed_subnets = [
     dependency.subnet.outputs.id,
+    dependency.subnet_azure_devops.outputs.id,
   ]
 
   subnet_id       = dependency.subnet.outputs.id


### PR DESCRIPTION
Enable Azure DevOps vnet for the staging slot of CGN function app. This needed by https://github.com/pagopa/io-functions-cgn/pull/15 to perform healthcheck on the staging slot before swapping.