### PR TITLE
[#VF-10] Added new apim endpoint to support newsletters API

### DIFF
--- a/prod/westeurope/internal/api/apim/api_management_api_io_payportal/policy.xml
+++ b/prod/westeurope/internal/api/apim/api_management_api_io_payportal/policy.xml
@@ -9,6 +9,7 @@
     <cors>
       <allowed-origins>
         <origin>https://io-p-cdnendpoint-iopayportal.azureedge.net/</origin> <!-- CDN frontend io-payportal -->
+        <origin>https://io.italia.it/</origin>
       </allowed-origins>
       <allowed-methods>
         <method>POST</method>

--- a/prod/westeurope/internal/api/apim/api_management_api_io_payportal/swagger.json.tmpl
+++ b/prod/westeurope/internal/api/apim/api_management_api_io_payportal/swagger.json.tmpl
@@ -184,6 +184,46 @@
           }
         }
       }
+    },
+    "/newsletters/groups/{id}/recipients": {
+      "post": {
+        "operationId": "PostNewslettersEmails",
+        "description": "Add an email to newsletter",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "description": "newsletter id",
+            "type": "string"
+          },
+          {
+            "name": "body",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/RecipientRequest"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Recipient added",
+            "schema": {
+              "$ref": "#/definitions/RecipientResponse"
+            }
+          },
+          "400": {
+            "description": "Bad request"
+          },
+          "401": {
+            "description": "not authenticated"
+          },
+          "500": {
+            "description": "generic error"
+          }
+        }
+      }
     }
   },
   "definitions": {
@@ -228,6 +268,40 @@
     },
     "SpezzoniCausaleVersamentoItem": {
       "$ref": "https://raw.githubusercontent.com/pagopa/io-pagopa-proxy/v0.8.6/api_pagopa.yaml#/definitions/SpezzoniCausaleVersamentoItem"
+    },
+    "RecipientRequest": {
+      "type": "object",
+      "required": [
+        "email",
+        "recaptchaToken"
+      ],
+      "properties": {
+        "name": {
+          "type": "string"
+        },
+        "email": {
+          "type": "string",
+          "format": "email"
+        },
+        "recaptchaToken": {
+          "type": "string"
+        }
+      }
+    },
+    "RecipientResponse": {
+      "type": "object",
+      "required": [
+        "email"
+      ],
+      "properties": {
+        "name": {
+          "type": "string"
+        },
+        "email": {
+          "type": "string",
+          "format": "email"
+        }
+      }
     }
   }
 }


### PR DESCRIPTION
#### Description

The goal of this PR is to configure a new endpoint exposed through apim to support the new api of [io-pay-portal](https://github.com/pagopa/io-pay-portal/pull/22).

#### List of changes

1. Updated apim spec for _io-pay-portal_.
2. Updated apim policy to accept requests from _io.italia.it_.