### PR TITLE
[Vf-10] Updated configuration for newsletters api - io-pay-portal

### DIFF
--- a/prod/westeurope/internal/api/apim/api_management_api_io_payportal/policy.xml
+++ b/prod/westeurope/internal/api/apim/api_management_api_io_payportal/policy.xml
@@ -10,6 +10,7 @@
       <allowed-origins>
         <origin>https://io-p-cdnendpoint-iopayportal.azureedge.net/</origin> <!-- CDN frontend io-payportal -->
         <origin>https://io.italia.it/</origin>
+        <origin>https://www.pagopa.gov.it/</origin>
       </allowed-origins>
       <allowed-methods>
         <method>POST</method>

--- a/prod/westeurope/internal/api/apim/api_management_api_io_payportal/swagger.json.tmpl
+++ b/prod/westeurope/internal/api/apim/api_management_api_io_payportal/swagger.json.tmpl
@@ -185,17 +185,28 @@
         }
       }
     },
-    "/newsletters/groups/{id}/recipients": {
+    "/newsletters/{idClient}/lists/{idList}/recipients": {
       "post": {
         "operationId": "PostNewslettersEmails",
         "description": "Add an email to newsletter",
         "parameters": [
           {
-            "name": "id",
+            "name": "idList",
             "in": "path",
             "required": true,
-            "description": "newsletter id",
+            "description": "list id",
             "type": "string"
+          },
+          {
+            "name": "idClient",
+            "in": "path",
+            "required": true,
+            "description": "client id",
+            "type": "string",
+            "enum": [
+              "io",
+              "pagopa"
+            ]
           },
           {
             "name": "body",
@@ -216,8 +227,8 @@
           "400": {
             "description": "Bad request"
           },
-          "401": {
-            "description": "not authenticated"
+          "403": {
+            "description": "forbidden"
           },
           "500": {
             "description": "generic error"
@@ -285,6 +296,12 @@
         },
         "recaptchaToken": {
           "type": "string"
+        },
+        "groups": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
         }
       }
     },

--- a/prod/westeurope/internal/api/functions_iopayportal/function_app/terragrunt.hcl
+++ b/prod/westeurope/internal/api/functions_iopayportal/function_app/terragrunt.hcl
@@ -99,8 +99,7 @@ inputs = {
   app_settings_secrets = {
     key_vault_id = dependency.key_vault.outputs.id
     map = {
-      RECAPTCHA_SECRET_IO     = "newsletter-GOOGLE-RECAPTCHA-SECRET-IO"
-      RECAPTCHA_SECRET_PAGOPA = "newsletter-GOOGLE-RECAPTCHA-SECRET-PAGOPA"
+      RECAPTCHA_SECRET = "newsletter-GOOGLE-RECAPTCHA-SECRET"
       # Mailup account:
       MAILUP_CLIENT_ID = "newsletter-MAILUP-CLIENT-ID"
       MAILUP_SECRET    = "newsletter-MAILUP-SECRET"

--- a/prod/westeurope/internal/api/functions_iopayportal/function_app/terragrunt.hcl
+++ b/prod/westeurope/internal/api/functions_iopayportal/function_app/terragrunt.hcl
@@ -86,8 +86,8 @@ inputs = {
     FETCH_KEEPALIVE_TIMEOUT             = "60000"
 
     // Mailup groups and lists
-    MAILUP_ALLOWED_GROUPS=30,31,32,21,29
-    MAILUP_ALLOWED_LISTS=2,4 
+    MAILUP_ALLOWED_GROUPS = "30,31,32,21,29"
+    MAILUP_ALLOWED_LISTS  = "2,4" 
     
     SLOT_TASK_HUBNAME = "ProductionTaskHub"
 
@@ -99,7 +99,7 @@ inputs = {
   app_settings_secrets = {
     key_vault_id = dependency.key_vault.outputs.id
     map = {
-      RECAPTCHA_SECRET_IO = "newsletter-GOOGLE-RECAPTCHA-SECRET-IO"
+      RECAPTCHA_SECRET_IO     = "newsletter-GOOGLE-RECAPTCHA-SECRET-IO"
       RECAPTCHA_SECRET_PAGOPA = "newsletter-GOOGLE-RECAPTCHA-SECRET-PAGOPA"
       # Mailup account:
       MAILUP_CLIENT_ID = "newsletter-MAILUP-CLIENT-ID"

--- a/prod/westeurope/internal/api/functions_iopayportal/function_app/terragrunt.hcl
+++ b/prod/westeurope/internal/api/functions_iopayportal/function_app/terragrunt.hcl
@@ -85,6 +85,10 @@ inputs = {
     FETCH_KEEPALIVE_FREE_SOCKET_TIMEOUT = "30000"
     FETCH_KEEPALIVE_TIMEOUT             = "60000"
 
+    // Mailup groups and lists
+    MAILUP_ALLOWED_GROUPS=30,31,32,21,29
+    MAILUP_ALLOWED_LISTS=2,4 
+    
     SLOT_TASK_HUBNAME = "ProductionTaskHub"
 
     # this app settings is required to solve the issue:
@@ -95,7 +99,8 @@ inputs = {
   app_settings_secrets = {
     key_vault_id = dependency.key_vault.outputs.id
     map = {
-      RECAPTCHA_SECRET = "newsletter-GOOGLE-RECAPTCHA-SECRET"
+      RECAPTCHA_SECRET_IO = "newsletter-GOOGLE-RECAPTCHA-SECRET-IO"
+      RECAPTCHA_SECRET_PAGOPA = "newsletter-GOOGLE-RECAPTCHA-SECRET-PAGOPA"
       # Mailup account:
       MAILUP_CLIENT_ID = "newsletter-MAILUP-CLIENT-ID"
       MAILUP_SECRET    = "newsletter-MAILUP-SECRET"

--- a/prod/westeurope/internal/api/functions_iopayportal/function_app_slot_staging/terragrunt.hcl
+++ b/prod/westeurope/internal/api/functions_iopayportal/function_app_slot_staging/terragrunt.hcl
@@ -92,6 +92,10 @@ inputs = {
     FETCH_KEEPALIVE_FREE_SOCKET_TIMEOUT = "30000"
     FETCH_KEEPALIVE_TIMEOUT             = "60000"
 
+    // Mailup groups and lists
+    MAILUP_ALLOWED_GROUPS=30,31,32,21,29
+    MAILUP_ALLOWED_LISTS=2,4 
+
     SLOT_TASK_HUBNAME = "StagingTaskHub"
 
     # this app settings is required to solve the issue:
@@ -102,7 +106,8 @@ inputs = {
   app_settings_secrets = {
     key_vault_id = dependency.key_vault.outputs.id
     map = {
-      RECAPTCHA_SECRET = "newsletter-GOOGLE-RECAPTCHA-SECRET"
+      RECAPTCHA_SECRET_IO = "newsletter-GOOGLE-RECAPTCHA-SECRET-IO"
+      RECAPTCHA_SECRET_PAGOPA = "newsletter-GOOGLE-RECAPTCHA-SECRET-PAGOPA"
       # Mailup account:
       MAILUP_CLIENT_ID = "newsletter-MAILUP-CLIENT-ID"
       MAILUP_SECRET    = "newsletter-MAILUP-SECRET"

--- a/prod/westeurope/internal/api/functions_iopayportal/function_app_slot_staging/terragrunt.hcl
+++ b/prod/westeurope/internal/api/functions_iopayportal/function_app_slot_staging/terragrunt.hcl
@@ -93,8 +93,8 @@ inputs = {
     FETCH_KEEPALIVE_TIMEOUT             = "60000"
 
     // Mailup groups and lists
-    MAILUP_ALLOWED_GROUPS=30,31,32,21,29
-    MAILUP_ALLOWED_LISTS=2,4 
+    MAILUP_ALLOWED_GROUPS = "30,31,32,21,29"
+    MAILUP_ALLOWED_LISTS  = "2,4" 
 
     SLOT_TASK_HUBNAME = "StagingTaskHub"
 
@@ -106,7 +106,7 @@ inputs = {
   app_settings_secrets = {
     key_vault_id = dependency.key_vault.outputs.id
     map = {
-      RECAPTCHA_SECRET_IO = "newsletter-GOOGLE-RECAPTCHA-SECRET-IO"
+      RECAPTCHA_SECRET_IO     = "newsletter-GOOGLE-RECAPTCHA-SECRET-IO"
       RECAPTCHA_SECRET_PAGOPA = "newsletter-GOOGLE-RECAPTCHA-SECRET-PAGOPA"
       # Mailup account:
       MAILUP_CLIENT_ID = "newsletter-MAILUP-CLIENT-ID"

--- a/prod/westeurope/internal/api/functions_iopayportal/function_app_slot_staging/terragrunt.hcl
+++ b/prod/westeurope/internal/api/functions_iopayportal/function_app_slot_staging/terragrunt.hcl
@@ -106,8 +106,7 @@ inputs = {
   app_settings_secrets = {
     key_vault_id = dependency.key_vault.outputs.id
     map = {
-      RECAPTCHA_SECRET_IO     = "newsletter-GOOGLE-RECAPTCHA-SECRET-IO"
-      RECAPTCHA_SECRET_PAGOPA = "newsletter-GOOGLE-RECAPTCHA-SECRET-PAGOPA"
+      RECAPTCHA_SECRET = "newsletter-GOOGLE-RECAPTCHA-SECRET"
       # Mailup account:
       MAILUP_CLIENT_ID = "newsletter-MAILUP-CLIENT-ID"
       MAILUP_SECRET    = "newsletter-MAILUP-SECRET"


### PR DESCRIPTION
#### Description

This PR introduces some updates related to the [io-pay-portal](https://github.com/pagopa/io-pay-portal) configuration.

#### List of changes

1.  Updated apim spec for _io-pay-portal_ according to [this](https://github.com/pagopa/io-pay-portal/pull/27) refactoring;
2. Updated apim policy to accept requests from _https://www.pagopa.gov.it/_;
3. Added `MAILUP_ALLOWED_GROUPS` and `MAILUP_ALLOWED_LISTS` envs variables;
4. Rename secret `newsletter-GOOGLE-RECAPTCHA-SECRET` in `newsletter-GOOGLE-RECAPTCHA-SECRET-IO`
5. Added new secret `newsletter-GOOGLE-RECAPTCHA-SECRET-PAGOPA`
