### PR TITLE
[IOPAY-86] add `IO_PAY_ORIGIN ` var env

### DIFF
--- a/prod/westeurope/internal/api/functions_iopayportal/function_app/terragrunt.hcl
+++ b/prod/westeurope/internal/api/functions_iopayportal/function_app/terragrunt.hcl
@@ -100,6 +100,7 @@ inputs = {
     WEBSITE_CONTENTSHARE = "io-p-func-iopayportal-content"
 
     IO_PAY_CHALLENGE_RESUME_URL = "https://${dependency.storage_account_iopay.outputs.primary_web_host}/response.html?id=idTransaction"
+    IO_PAY_ORIGIN = "https://${dependency.storage_account_iopay.outputs.primary_web_host}"
   }
 
   app_settings_secrets = {

--- a/prod/westeurope/internal/api/functions_iopayportal/function_app/terragrunt.hcl
+++ b/prod/westeurope/internal/api/functions_iopayportal/function_app/terragrunt.hcl
@@ -100,7 +100,7 @@ inputs = {
     WEBSITE_CONTENTSHARE = "io-p-func-iopayportal-content"
 
     IO_PAY_CHALLENGE_RESUME_URL = "https://io-p-cdnendpoint-iopay.azureedge.net/response.html?id=idTransaction"
-    IO_PAY_ORIGIN = "https://io-p-cdnendpoint-iopay.azureedge.net/"
+    IO_PAY_ORIGIN = "https://io-p-cdnendpoint-iopay.azureedge.net"
   }
 
   app_settings_secrets = {

--- a/prod/westeurope/internal/api/functions_iopayportal/function_app/terragrunt.hcl
+++ b/prod/westeurope/internal/api/functions_iopayportal/function_app/terragrunt.hcl
@@ -99,8 +99,8 @@ inputs = {
     # https://github.com/terraform-providers/terraform-provider-azurerm/issues/10499
     WEBSITE_CONTENTSHARE = "io-p-func-iopayportal-content"
 
-    IO_PAY_CHALLENGE_RESUME_URL = "https://${dependency.storage_account_iopay.outputs.primary_web_host}/response.html?id=idTransaction"
-    IO_PAY_ORIGIN = "https://${dependency.storage_account_iopay.outputs.primary_web_host}"
+    IO_PAY_CHALLENGE_RESUME_URL = "https://io-p-cdnendpoint-iopay.azureedge.net/response.html?id=idTransaction"
+    IO_PAY_ORIGIN = "https://io-p-cdnendpoint-iopay.azureedge.net/"
   }
 
   app_settings_secrets = {

--- a/prod/westeurope/internal/api/functions_iopayportal/function_app_slot_staging/terragrunt.hcl
+++ b/prod/westeurope/internal/api/functions_iopayportal/function_app_slot_staging/terragrunt.hcl
@@ -106,8 +106,8 @@ inputs = {
     # https://github.com/terraform-providers/terraform-provider-azurerm/issues/10499
     WEBSITE_CONTENTSHARE = "staging-content"
 
-    IO_PAY_CHALLENGE_RESUME_URL = "https://${dependency.storage_account_iopay.outputs.primary_web_host}/response.html?id=idTransaction"
-    IO_PAY_ORIGIN = "https://${dependency.storage_account_iopay.outputs.primary_web_host}"
+    IO_PAY_CHALLENGE_RESUME_URL = "https://io-p-cdnendpoint-iopay.azureedge.net//response.html?id=idTransaction"
+    IO_PAY_ORIGIN = "https://io-p-cdnendpoint-iopay.azureedge.net/"
   }
 
   app_settings_secrets = {

--- a/prod/westeurope/internal/api/functions_iopayportal/function_app_slot_staging/terragrunt.hcl
+++ b/prod/westeurope/internal/api/functions_iopayportal/function_app_slot_staging/terragrunt.hcl
@@ -107,7 +107,7 @@ inputs = {
     WEBSITE_CONTENTSHARE = "staging-content"
 
     IO_PAY_CHALLENGE_RESUME_URL = "https://io-p-cdnendpoint-iopay.azureedge.net//response.html?id=idTransaction"
-    IO_PAY_ORIGIN = "https://io-p-cdnendpoint-iopay.azureedge.net/"
+    IO_PAY_ORIGIN = "https://io-p-cdnendpoint-iopay.azureedge.net"
   }
 
   app_settings_secrets = {

--- a/prod/westeurope/internal/api/functions_iopayportal/function_app_slot_staging/terragrunt.hcl
+++ b/prod/westeurope/internal/api/functions_iopayportal/function_app_slot_staging/terragrunt.hcl
@@ -107,6 +107,7 @@ inputs = {
     WEBSITE_CONTENTSHARE = "staging-content"
 
     IO_PAY_CHALLENGE_RESUME_URL = "https://${dependency.storage_account_iopay.outputs.primary_web_host}/response.html?id=idTransaction"
+    IO_PAY_ORIGIN = "https://${dependency.storage_account_iopay.outputs.primary_web_host}"
   }
 
   app_settings_secrets = {


### PR DESCRIPTION
### Purpose
This PR add new env variable `IO_PAY_ORIGIN` used by `io-pay-portal` function in `api/v1/transactions/{id}/method` 