### PR TITLE
[#177494601] Disable CGN Queue triggered functions on staging slot

### DIFF
--- a/prod/westeurope/cgn/functions_cgn/function_app_slot_staging/terragrunt.hcl
+++ b/prod/westeurope/cgn/functions_cgn/function_app_slot_staging/terragrunt.hcl
@@ -140,6 +140,9 @@ inputs = {
 
     CGN_UPPER_BOUND_AGE  = 61
     EYCA_UPPER_BOUND_AGE = 51
+
+    # Disabled functions on slot - slot settings only
+    "AzureWebJobs.ContinueEycaActivation.Disabled" = "1"
   }
 
   app_settings_secrets = {


### PR DESCRIPTION
This PR disable `ContinueEycaActivation` Queue triggered functions in order to avoid wrong staging execution due to access to a single queue.