### PR TITLE
[#IP-85] Expose IDP list through public endpoint

### DIFF
--- a/prod/westeurope/common/cdn/cdn_endpoint_fnassets/terragrunt.hcl
+++ b/prod/westeurope/common/cdn/cdn_endpoint_fnassets/terragrunt.hcl
@@ -29,18 +29,18 @@ inputs = {
 
   global_delivery_rule = {
 
-    cache_expiration_action = {
+    cache_expiration_action = [{
       behavior = "Override"
       duration = "08:00:00"
-    }
+    }]
 
     cache_key_query_string_action = null
-    modify_request_header_action = {
+    modify_request_header_action = [{
       action = "Append"
       name   = "x-functions-key"
       value  = dependency.function_app.outputs.default_key
-    }
-    modify_response_header_action = null
+    }]
+    modify_response_header_action = []
 
   }
 

--- a/prod/westeurope/common/cdn/cdn_endpoint_fnassets/terragrunt.hcl
+++ b/prod/westeurope/common/cdn/cdn_endpoint_fnassets/terragrunt.hcl
@@ -70,6 +70,14 @@ inputs = {
       match_values = ["/status"]
       behavior     = "Override"
       duration     = "00:05:00"
+    },
+    {
+      name         = "spididpscache"
+      order        = 4
+      operator     = "BeginsWith"
+      match_values = ["/spid/idps"]
+      behavior     = "Override"
+      duration     = "24:00:00"
     }
   ]
 


### PR DESCRIPTION
### List of changes

Add cache for path /spid/idps*

### Motivation and context

The locations /spid/idps will be used by clients to retrieve data about ID Providers (Metedata and logo images).
Those data are pretty static, so the cache will be very effective to improve performance and reduce storage access.

### Type of changes

- [ ] Add new resources
- [x] Update configuration to existing resources
- [ ] Remove existing resources

### Does this introduce a change to production resources with possible user impact?

- [ ] Yes, users may be impacted applying this change
- [x] No

### Other information

---

### Who will help you to apply PR (reserved to mantainers)

<!--- Who will help you to apply this PR -->

- [ ] uolter
- [ ] pasqualedevita
- [ ] myself

### PR apply status (reserved to mantainers)

<!--- PR apply status -->

- [x] Not applied
- [ ] Partially applied
- [ ] Applied

#### if partially applied, why?

<!--- Describe the blocking cause -->
