### PR TITLE
[#IP-49] Use production resources for fn-pushnotif

### DIFF
--- a/prod/westeurope/notifications/functions_pushnotif/function_app/terragrunt.hcl
+++ b/prod/westeurope/notifications/functions_pushnotif/function_app/terragrunt.hcl
@@ -7,19 +7,16 @@ dependency "subnet" {
 }
 
 dependency "notification_hub" {
-  # config_path = "../../notification_hub"
-  config_path = "../../sandbox/notification_hub"
+  config_path = "../../common/notification_hub"
 }
 
 # Internal
 dependency "storage_notifications" {
-  # config_path = "../../../internal/api/storage_notifications/account"
-  config_path = "../../sandbox/storage_notifications/account"
+  config_path = "../../internal/api/storage_notifications/account"
 }
 
 dependency "storage_notifications_queue_push-notifications" {
-  # config_path = "../../../internal/api/storage_notifications/queue_push-notifications"
-  config_path = "../../sandbox/storage_notifications/queue_push-notifications"
+  config_path = "../../internal/api/storage_notifications/queue_push-notifications"
 }
 
 # Common
@@ -89,7 +86,7 @@ inputs = {
     SLOT_TASK_HUBNAME = "ProductionTaskHub"
 
     // Disable functions
-    "AzureWebJobs.HandleNHNotificationCall.Disabled" = "0"
+    "AzureWebJobs.HandleNHNotificationCall.Disabled" = "1" // we keep it disabled until we route production traffic here
 
     # this app settings is required to solve the issue:
     # https://github.com/terraform-providers/terraform-provider-azurerm/issues/10499
@@ -99,7 +96,7 @@ inputs = {
   app_settings_secrets = {
     key_vault_id = dependency.key_vault.outputs.id
     map = {
-      AZURE_NH_ENDPOINT = "notifications-AZURE-NHSANDBOX-ENDPOINT"
+      AZURE_NH_ENDPOINT = "common-AZURE-NH-ENDPOINT"
     }
   }
 

--- a/prod/westeurope/notifications/functions_pushnotif/function_app/terragrunt.hcl
+++ b/prod/westeurope/notifications/functions_pushnotif/function_app/terragrunt.hcl
@@ -7,16 +7,16 @@ dependency "subnet" {
 }
 
 dependency "notification_hub" {
-  config_path = "../../common/notification_hub"
+  config_path = "../../../common/notification_hub"
 }
 
 # Internal
 dependency "storage_notifications" {
-  config_path = "../../internal/api/storage_notifications/account"
+  config_path = "../../../internal/api/storage_notifications/account"
 }
 
 dependency "storage_notifications_queue_push-notifications" {
-  config_path = "../../internal/api/storage_notifications/queue_push-notifications"
+  config_path = "../../../internal/api/storage_notifications/queue_push-notifications"
 }
 
 # Common

--- a/prod/westeurope/notifications/functions_pushnotif/function_app_slot_staging/terragrunt.hcl
+++ b/prod/westeurope/notifications/functions_pushnotif/function_app_slot_staging/terragrunt.hcl
@@ -11,16 +11,16 @@ dependency "function_app" {
 }
 
 dependency "notification_hub" {
-  config_path = "../../../../common/notification_hub"
+  config_path = "../../../common/notification_hub"
 }
 
 # Internal
 dependency "storage_notifications" {
-  config_path = "../../internal/api/storage_notifications/account"
+  config_path = "../../../internal/api/storage_notifications/account"
 }
 
 dependency "storage_notifications_queue_push-notifications" {
-  config_path = "../../internal/api/storage_notifications/queue_push-notifications"
+  config_path = "../../../internal/api/storage_notifications/queue_push-notifications"
 }
 
 # Common

--- a/prod/westeurope/notifications/functions_pushnotif/function_app_slot_staging/terragrunt.hcl
+++ b/prod/westeurope/notifications/functions_pushnotif/function_app_slot_staging/terragrunt.hcl
@@ -11,19 +11,16 @@ dependency "function_app" {
 }
 
 dependency "notification_hub" {
-  # config_path = "../../notification_hub"
-  config_path = "../../sandbox/notification_hub"
+  config_path = "../../../../common/notification_hub"
 }
 
 # Internal
 dependency "storage_notifications" {
-  # config_path = "../../../internal/api/storage_notifications/account"
-  config_path = "../../sandbox/storage_notifications/account"
+  config_path = "../../internal/api/storage_notifications/account"
 }
 
 dependency "storage_notifications_queue_push-notifications" {
-  # config_path = "../../../internal/api/storage_notifications/queue_push-notifications"
-  config_path = "../../sandbox/storage_notifications/queue_push-notifications"
+  config_path = "../../internal/api/storage_notifications/queue_push-notifications"
 }
 
 # Common
@@ -95,7 +92,7 @@ inputs = {
   app_settings_secrets = {
     key_vault_id = dependency.key_vault.outputs.id
     map = {
-      AZURE_NH_ENDPOINT = "notifications-AZURE-NHSANDBOX-ENDPOINT"
+      AZURE_NH_ENDPOINT = "common-AZURE-NH-ENDPOINT"
     }
   }
 


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

### List of changes
<!--- Describe your changes in detail -->
Configure `io-p-fn3-pushnotif` to use production queue and notification hub. 

### Motivation and context
<!--- Why is this change required? What problem does it solve? -->
These changes are in preparation of the traffic switch from `io-p-fn3-appasync` to `io-p-fn3-pushnotif`. At the moment the latter has the handler disabled, so that it won't consume events from notification queue. 

Sandbox resources are kept for further development-time tests.

### Type of changes

- [ ] Add new resources
- [x] Update configuration to existing resources
- [ ] Remove existing resources

### Does this introduce a change to production resources with possible user impact?

- [ ] Yes, users may be impacted applying this change
- [x] No

### Does this introduce an unwanted change on infrastructure? Check terraform plan execution result

- [ ] Yes
- [x] No

### Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->

---

### If PR is partially applied, why? (reserved to mantainers)

<!--- Describe the blocking cause -->
