### PR TITLE
[#IP-49]  Switch notification traffic from fn3-appasync to fn3-pushnotif

### DIFF
--- a/prod/westeurope/internal/api/functions_app_async/function_app/terragrunt.hcl
+++ b/prod/westeurope/internal/api/functions_app_async/function_app/terragrunt.hcl
@@ -172,7 +172,7 @@ inputs = {
     #"AzureWebJobs.UpsertUserDataProcessing.Disabled"               = "1"
     #"AzureWebJobs.UpsertedProfileOrchestrator.Disabled"            = "1"
     #"AzureWebJobs.UpsertedUserDataProcessingOrchestrator.Disabled" = "1"
-    "AzureWebJobs.HandleNHNotificationCall.Disabled" = "0"
+    "AzureWebJobs.HandleNHNotificationCall.Disabled" = "1" // Messages are handled by io-p-fn3-pushnotif
     "AzureWebJobs.StoreSpidLogs.Disabled"            = "0"
 
     # Cashback

--- a/prod/westeurope/notifications/functions_pushnotif/function_app/terragrunt.hcl
+++ b/prod/westeurope/notifications/functions_pushnotif/function_app/terragrunt.hcl
@@ -7,19 +7,16 @@ dependency "subnet" {
 }
 
 dependency "notification_hub" {
-  # config_path = "../../notification_hub"
-  config_path = "../../sandbox/notification_hub"
+  config_path = "../../common/notification_hub"
 }
 
 # Internal
 dependency "storage_notifications" {
-  # config_path = "../../../internal/api/storage_notifications/account"
-  config_path = "../../sandbox/storage_notifications/account"
+  config_path = "../../internal/api/storage_notifications/account"
 }
 
 dependency "storage_notifications_queue_push-notifications" {
-  # config_path = "../../../internal/api/storage_notifications/queue_push-notifications"
-  config_path = "../../sandbox/storage_notifications/queue_push-notifications"
+  config_path = "../../internal/api/storage_notifications/queue_push-notifications"
 }
 
 # Common
@@ -89,7 +86,7 @@ inputs = {
     SLOT_TASK_HUBNAME = "ProductionTaskHub"
 
     // Disable functions
-    "AzureWebJobs.HandleNHNotificationCall.Disabled" = "0"
+    "AzureWebJobs.HandleNHNotificationCall.Disabled" = "1" // we keep it disabled until we route production traffic here
 
     # this app settings is required to solve the issue:
     # https://github.com/terraform-providers/terraform-provider-azurerm/issues/10499
@@ -99,7 +96,7 @@ inputs = {
   app_settings_secrets = {
     key_vault_id = dependency.key_vault.outputs.id
     map = {
-      AZURE_NH_ENDPOINT = "notifications-AZURE-NHSANDBOX-ENDPOINT"
+      AZURE_NH_ENDPOINT = "common-AZURE-NH-ENDPOINT"
     }
   }
 

--- a/prod/westeurope/notifications/functions_pushnotif/function_app/terragrunt.hcl
+++ b/prod/westeurope/notifications/functions_pushnotif/function_app/terragrunt.hcl
@@ -86,7 +86,7 @@ inputs = {
     SLOT_TASK_HUBNAME = "ProductionTaskHub"
 
     // Disable functions
-    "AzureWebJobs.HandleNHNotificationCall.Disabled" = "1" // we keep it disabled until we route production traffic here
+    "AzureWebJobs.HandleNHNotificationCall.Disabled" = "0"
 
     # this app settings is required to solve the issue:
     # https://github.com/terraform-providers/terraform-provider-azurerm/issues/10499

--- a/prod/westeurope/notifications/functions_pushnotif/function_app/terragrunt.hcl
+++ b/prod/westeurope/notifications/functions_pushnotif/function_app/terragrunt.hcl
@@ -7,16 +7,16 @@ dependency "subnet" {
 }
 
 dependency "notification_hub" {
-  config_path = "../../common/notification_hub"
+  config_path = "../../../common/notification_hub"
 }
 
 # Internal
 dependency "storage_notifications" {
-  config_path = "../../internal/api/storage_notifications/account"
+  config_path = "../../../internal/api/storage_notifications/account"
 }
 
 dependency "storage_notifications_queue_push-notifications" {
-  config_path = "../../internal/api/storage_notifications/queue_push-notifications"
+  config_path = "../../../internal/api/storage_notifications/queue_push-notifications"
 }
 
 # Common

--- a/prod/westeurope/notifications/functions_pushnotif/function_app_slot_staging/terragrunt.hcl
+++ b/prod/westeurope/notifications/functions_pushnotif/function_app_slot_staging/terragrunt.hcl
@@ -11,16 +11,16 @@ dependency "function_app" {
 }
 
 dependency "notification_hub" {
-  config_path = "../../../../common/notification_hub"
+  config_path = "../../../common/notification_hub"
 }
 
 # Internal
 dependency "storage_notifications" {
-  config_path = "../../internal/api/storage_notifications/account"
+  config_path = "../../../internal/api/storage_notifications/account"
 }
 
 dependency "storage_notifications_queue_push-notifications" {
-  config_path = "../../internal/api/storage_notifications/queue_push-notifications"
+  config_path = "../../../internal/api/storage_notifications/queue_push-notifications"
 }
 
 # Common

--- a/prod/westeurope/notifications/functions_pushnotif/function_app_slot_staging/terragrunt.hcl
+++ b/prod/westeurope/notifications/functions_pushnotif/function_app_slot_staging/terragrunt.hcl
@@ -11,19 +11,16 @@ dependency "function_app" {
 }
 
 dependency "notification_hub" {
-  # config_path = "../../notification_hub"
-  config_path = "../../sandbox/notification_hub"
+  config_path = "../../../../common/notification_hub"
 }
 
 # Internal
 dependency "storage_notifications" {
-  # config_path = "../../../internal/api/storage_notifications/account"
-  config_path = "../../sandbox/storage_notifications/account"
+  config_path = "../../internal/api/storage_notifications/account"
 }
 
 dependency "storage_notifications_queue_push-notifications" {
-  # config_path = "../../../internal/api/storage_notifications/queue_push-notifications"
-  config_path = "../../sandbox/storage_notifications/queue_push-notifications"
+  config_path = "../../internal/api/storage_notifications/queue_push-notifications"
 }
 
 # Common
@@ -95,7 +92,7 @@ inputs = {
   app_settings_secrets = {
     key_vault_id = dependency.key_vault.outputs.id
     map = {
-      AZURE_NH_ENDPOINT = "notifications-AZURE-NHSANDBOX-ENDPOINT"
+      AZURE_NH_ENDPOINT = "common-AZURE-NH-ENDPOINT"
     }
   }
 


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->
This PR is draft as it needs #486 before applying.

### List of changes
<!--- Describe your changes in detail -->
* Disable `HandleNHNotificationCall` on `io-p-fn3-appasync`
* Enable `HandleNHNotificationCall` on `io-p-fn3-appasync`

### Motivation and context
<!--- Why is this change required? What problem does it solve? -->
To move traffic from `io-p-fn3-appasync` to `io-p-fn3-pushnotif`, with the plan to dismantle the first. 
Changes must be applied in the following order:
* first disable
* the enable
This is to avoid both functions to consume the same messages con currentlty.

### Type of changes

- [ ] Add new resources
- [x] Update configuration to existing resources
- [ ] Remove existing resources

### Does this introduce a change to production resources with possible user impact?

- [x] Yes, users may be impacted applying this change
- [ ] No

### Does this introduce an unwanted change on infrastructure? Check terraform plan execution result

- [x] Yes
- [ ] No

unwanted changes on `io-p-fn3-appasync`:
- version = "3.0.13353.0" -> "~3"
- add "azurerm_template_deployment" "versioning"

they are safe to apply, we can consider an update to terraform configuration (no breaking changes)

### Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->

---

### If PR is partially applied, why? (reserved to mantainers)

<!--- Describe the blocking cause -->
