### PR TITLE
[#IP-119] Remove notification configuration from io-p-fn3-appasync

### DIFF
--- a/prod/westeurope/internal/api/functions_app_async/function_app/terragrunt.hcl
+++ b/prod/westeurope/internal/api/functions_app_async/function_app/terragrunt.hcl
@@ -172,7 +172,7 @@ inputs = {
     #"AzureWebJobs.UpsertUserDataProcessing.Disabled"               = "1"
     #"AzureWebJobs.UpsertedProfileOrchestrator.Disabled"            = "1"
     #"AzureWebJobs.UpsertedUserDataProcessingOrchestrator.Disabled" = "1"
-    "AzureWebJobs.HandleNHNotificationCall.Disabled" = "0"
+    "AzureWebJobs.HandleNHNotificationCall.Disabled" = "1" // Messages are handled by io-p-fn3-pushnotif
     "AzureWebJobs.StoreSpidLogs.Disabled"            = "0"
 
     # Cashback

--- a/prod/westeurope/internal/api/functions_app_async/function_app/terragrunt.hcl
+++ b/prod/westeurope/internal/api/functions_app_async/function_app/terragrunt.hcl
@@ -61,18 +61,6 @@ dependency "key_vault" {
   config_path = "../../../../common/key_vault"
 }
 
-dependency "notification_hub" {
-  config_path = "../../../../common/notification_hub"
-}
-
-dependency "notification_queue" {
-  config_path = "../../storage_notifications/queue_push-notifications"
-}
-
-dependency "notification_storage_account" {
-  config_path = "../../storage_notifications/account"
-}
-
 # Include all settings from the root terragrunt.hcl file
 include {
   path = find_in_parent_folders()
@@ -142,11 +130,6 @@ inputs = {
     FETCH_KEEPALIVE_FREE_SOCKET_TIMEOUT = "30000"
     FETCH_KEEPALIVE_TIMEOUT             = "60000"
 
-    // Push notifications
-    AZURE_NH_HUB_NAME                       = dependency.notification_hub.outputs.name
-    NOTIFICATIONS_QUEUE_NAME                = dependency.notification_queue.outputs.name
-    NOTIFICATIONS_STORAGE_CONNECTION_STRING = dependency.notification_storage_account.outputs.primary_connection_string
-
     SLOT_TASK_HUBNAME = "ProductionTaskHub"
 
     // Disable functions
@@ -172,7 +155,6 @@ inputs = {
     #"AzureWebJobs.UpsertUserDataProcessing.Disabled"               = "1"
     #"AzureWebJobs.UpsertedProfileOrchestrator.Disabled"            = "1"
     #"AzureWebJobs.UpsertedUserDataProcessingOrchestrator.Disabled" = "1"
-    "AzureWebJobs.HandleNHNotificationCall.Disabled" = "1" // Messages are handled by io-p-fn3-pushnotif
     "AzureWebJobs.StoreSpidLogs.Disabled"            = "0"
 
     # Cashback
@@ -195,7 +177,6 @@ inputs = {
       MAILUP_SECRET                = "common-MAILUP2-SECRET"
       PUBLIC_API_KEY               = "apim-IO-SERVICE-KEY"
       SPID_LOGS_PUBLIC_KEY         = "funcapp-KEY-SPIDLOGS-PUB"
-      AZURE_NH_ENDPOINT            = "common-AZURE-NH-ENDPOINT"
     }
   }
 

--- a/prod/westeurope/internal/api/functions_app_async/function_app_slot_staging/terragrunt.hcl
+++ b/prod/westeurope/internal/api/functions_app_async/function_app_slot_staging/terragrunt.hcl
@@ -65,18 +65,6 @@ dependency "key_vault" {
   config_path = "../../../../common/key_vault"
 }
 
-dependency "notification_hub" {
-  config_path = "../../../../common/notification_hub"
-}
-
-dependency "notification_queue" {
-  config_path = "../../storage_notifications/queue_push-notifications"
-}
-
-dependency "notification_storage_account" {
-  config_path = "../../storage_notifications/account"
-}
-
 dependency "subnet_azure_devops" {
   config_path = "../../../../common/subnet_azure_devops"
 }
@@ -137,11 +125,6 @@ inputs = {
     FETCH_KEEPALIVE_FREE_SOCKET_TIMEOUT = "30000"
     FETCH_KEEPALIVE_TIMEOUT             = "60000"
 
-    // Push notifications
-    AZURE_NH_HUB_NAME                       = dependency.notification_hub.outputs.name
-    NOTIFICATIONS_QUEUE_NAME                = dependency.notification_queue.outputs.name
-    NOTIFICATIONS_STORAGE_CONNECTION_STRING = dependency.notification_storage_account.outputs.primary_connection_string
-
     SLOT_TASK_HUBNAME = "StagingTaskHub"
 
     # Disabled functions on slot - trigger, queue and timer
@@ -168,7 +151,6 @@ inputs = {
       MAILUP_SECRET                = "common-MAILUP2-SECRET"
       PUBLIC_API_KEY               = "apim-IO-SERVICE-KEY"
       SPID_LOGS_PUBLIC_KEY         = "funcapp-KEY-SPIDLOGS-PUB"
-      AZURE_NH_ENDPOINT            = "common-AZURE-NH-ENDPOINT"
     }
   }
 

--- a/prod/westeurope/notifications/functions_pushnotif/function_app/terragrunt.hcl
+++ b/prod/westeurope/notifications/functions_pushnotif/function_app/terragrunt.hcl
@@ -7,19 +7,16 @@ dependency "subnet" {
 }
 
 dependency "notification_hub" {
-  # config_path = "../../notification_hub"
-  config_path = "../../sandbox/notification_hub"
+  config_path = "../../common/notification_hub"
 }
 
 # Internal
 dependency "storage_notifications" {
-  # config_path = "../../../internal/api/storage_notifications/account"
-  config_path = "../../sandbox/storage_notifications/account"
+  config_path = "../../internal/api/storage_notifications/account"
 }
 
 dependency "storage_notifications_queue_push-notifications" {
-  # config_path = "../../../internal/api/storage_notifications/queue_push-notifications"
-  config_path = "../../sandbox/storage_notifications/queue_push-notifications"
+  config_path = "../../internal/api/storage_notifications/queue_push-notifications"
 }
 
 # Common
@@ -89,7 +86,7 @@ inputs = {
     SLOT_TASK_HUBNAME = "ProductionTaskHub"
 
     // Disable functions
-    "AzureWebJobs.HandleNHNotificationCall.Disabled" = "0"
+    "AzureWebJobs.HandleNHNotificationCall.Disabled" = "1" // we keep it disabled until we route production traffic here
 
     # this app settings is required to solve the issue:
     # https://github.com/terraform-providers/terraform-provider-azurerm/issues/10499
@@ -99,7 +96,7 @@ inputs = {
   app_settings_secrets = {
     key_vault_id = dependency.key_vault.outputs.id
     map = {
-      AZURE_NH_ENDPOINT = "notifications-AZURE-NHSANDBOX-ENDPOINT"
+      AZURE_NH_ENDPOINT = "common-AZURE-NH-ENDPOINT"
     }
   }
 

--- a/prod/westeurope/notifications/functions_pushnotif/function_app/terragrunt.hcl
+++ b/prod/westeurope/notifications/functions_pushnotif/function_app/terragrunt.hcl
@@ -86,7 +86,7 @@ inputs = {
     SLOT_TASK_HUBNAME = "ProductionTaskHub"
 
     // Disable functions
-    "AzureWebJobs.HandleNHNotificationCall.Disabled" = "1" // we keep it disabled until we route production traffic here
+    "AzureWebJobs.HandleNHNotificationCall.Disabled" = "0"
 
     # this app settings is required to solve the issue:
     # https://github.com/terraform-providers/terraform-provider-azurerm/issues/10499

--- a/prod/westeurope/notifications/functions_pushnotif/function_app/terragrunt.hcl
+++ b/prod/westeurope/notifications/functions_pushnotif/function_app/terragrunt.hcl
@@ -7,16 +7,16 @@ dependency "subnet" {
 }
 
 dependency "notification_hub" {
-  config_path = "../../common/notification_hub"
+  config_path = "../../../common/notification_hub"
 }
 
 # Internal
 dependency "storage_notifications" {
-  config_path = "../../internal/api/storage_notifications/account"
+  config_path = "../../../internal/api/storage_notifications/account"
 }
 
 dependency "storage_notifications_queue_push-notifications" {
-  config_path = "../../internal/api/storage_notifications/queue_push-notifications"
+  config_path = "../../../internal/api/storage_notifications/queue_push-notifications"
 }
 
 # Common

--- a/prod/westeurope/notifications/functions_pushnotif/function_app_slot_staging/terragrunt.hcl
+++ b/prod/westeurope/notifications/functions_pushnotif/function_app_slot_staging/terragrunt.hcl
@@ -11,16 +11,16 @@ dependency "function_app" {
 }
 
 dependency "notification_hub" {
-  config_path = "../../../../common/notification_hub"
+  config_path = "../../../common/notification_hub"
 }
 
 # Internal
 dependency "storage_notifications" {
-  config_path = "../../internal/api/storage_notifications/account"
+  config_path = "../../../internal/api/storage_notifications/account"
 }
 
 dependency "storage_notifications_queue_push-notifications" {
-  config_path = "../../internal/api/storage_notifications/queue_push-notifications"
+  config_path = "../../../internal/api/storage_notifications/queue_push-notifications"
 }
 
 # Common

--- a/prod/westeurope/notifications/functions_pushnotif/function_app_slot_staging/terragrunt.hcl
+++ b/prod/westeurope/notifications/functions_pushnotif/function_app_slot_staging/terragrunt.hcl
@@ -11,19 +11,16 @@ dependency "function_app" {
 }
 
 dependency "notification_hub" {
-  # config_path = "../../notification_hub"
-  config_path = "../../sandbox/notification_hub"
+  config_path = "../../../../common/notification_hub"
 }
 
 # Internal
 dependency "storage_notifications" {
-  # config_path = "../../../internal/api/storage_notifications/account"
-  config_path = "../../sandbox/storage_notifications/account"
+  config_path = "../../internal/api/storage_notifications/account"
 }
 
 dependency "storage_notifications_queue_push-notifications" {
-  # config_path = "../../../internal/api/storage_notifications/queue_push-notifications"
-  config_path = "../../sandbox/storage_notifications/queue_push-notifications"
+  config_path = "../../internal/api/storage_notifications/queue_push-notifications"
 }
 
 # Common
@@ -95,7 +92,7 @@ inputs = {
   app_settings_secrets = {
     key_vault_id = dependency.key_vault.outputs.id
     map = {
-      AZURE_NH_ENDPOINT = "notifications-AZURE-NHSANDBOX-ENDPOINT"
+      AZURE_NH_ENDPOINT = "common-AZURE-NH-ENDPOINT"
     }
   }
 


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->
This PR is draft as it needs https://github.com/pagopa/io-functions-app/pull/154 before apply.

### List of changes
<!--- Describe your changes in detail -->
Remove references to:
* Notification Hub
* Notification Queue

### Motivation and context
<!--- Why is this change required? What problem does it solve? -->
After notification traffic has been moved away from this functions app, there's no need to keep such references.

### Type of changes

- [ ] Add new resources
- [x] Update configuration to existing resources
- [ ] Remove existing resources

### Does this introduce a change to production resources with possible user impact?

- [ ] Yes, users may be impacted applying this change
- [x] No

### Does this introduce an unwanted change on infrastructure? Check terraform plan execution result

- [ ] Yes
- [ ] No

### Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->

---

### If PR is partially applied, why? (reserved to mantainers)

<!--- Describe the blocking cause -->
