### PR TITLE
[#IP-44] add RETRY_ATTEMPT_NUMBER, APPINSIGHTS_SAMPLING_PERCENTAGE variables

### DIFF
--- a/prod/westeurope/notifications/functions_pushnotif/function_app/terragrunt.hcl
+++ b/prod/westeurope/notifications/functions_pushnotif/function_app/terragrunt.hcl
@@ -88,6 +88,8 @@ inputs = {
     // activity default retry attempts
     RETRY_ATTEMPT_NUMBER = 10
 
+    APPINSIGHTS_SAMPLING_PERCENTAGE = 5
+
     // Disable functions
     "AzureWebJobs.HandleNHNotificationCall.Disabled" = "0"
 

--- a/prod/westeurope/notifications/functions_pushnotif/function_app/terragrunt.hcl
+++ b/prod/westeurope/notifications/functions_pushnotif/function_app/terragrunt.hcl
@@ -85,6 +85,9 @@ inputs = {
 
     SLOT_TASK_HUBNAME = "ProductionTaskHub"
 
+    // activity default retry attempts
+    RETRY_ATTEMPT_NUMBER = 10
+
     // Disable functions
     "AzureWebJobs.HandleNHNotificationCall.Disabled" = "0"
 

--- a/prod/westeurope/notifications/functions_pushnotif/function_app_slot_staging/terragrunt.hcl
+++ b/prod/westeurope/notifications/functions_pushnotif/function_app_slot_staging/terragrunt.hcl
@@ -81,6 +81,9 @@ inputs = {
 
     SLOT_TASK_HUBNAME = "StagingTaskHub"
 
+    // activity default retry attempts
+    RETRY_ATTEMPT_NUMBER = 3
+
     // Disable functions
     "AzureWebJobs.HandleNHNotificationCall.Disabled" = "1"
 

--- a/prod/westeurope/notifications/functions_pushnotif/function_app_slot_staging/terragrunt.hcl
+++ b/prod/westeurope/notifications/functions_pushnotif/function_app_slot_staging/terragrunt.hcl
@@ -84,6 +84,8 @@ inputs = {
     // activity default retry attempts
     RETRY_ATTEMPT_NUMBER = 10
 
+    APPINSIGHTS_SAMPLING_PERCENTAGE = 5
+
     // Disable functions
     "AzureWebJobs.HandleNHNotificationCall.Disabled" = "1"
 

--- a/prod/westeurope/notifications/functions_pushnotif/function_app_slot_staging/terragrunt.hcl
+++ b/prod/westeurope/notifications/functions_pushnotif/function_app_slot_staging/terragrunt.hcl
@@ -82,7 +82,7 @@ inputs = {
     SLOT_TASK_HUBNAME = "StagingTaskHub"
 
     // activity default retry attempts
-    RETRY_ATTEMPT_NUMBER = 3
+    RETRY_ATTEMPT_NUMBER = 10
 
     // Disable functions
     "AzureWebJobs.HandleNHNotificationCall.Disabled" = "1"


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

### List of changes
* add `RETRY_ATTEMPT_NUMBER` to `io-p-fn3-pushnotif`
* add `APPINSIGHTS_SAMPLING_PERCENTAGE` to `io-p-fn3-pushnotif`
<!--- Describe your changes in detail -->

### Motivation and context
It's introduced by https://github.com/pagopa/io-functions-pushnotifications/pull/4

<!--- Why is this change required? What problem does it solve? -->

### Type of changes

- [ ] Add new resources
- [x] Update configuration to existing resources
- [ ] Remove existing resources

### Does this introduce a change to production resources with possible user impact?

- [ ] Yes, users may be impacted applying this change
- [x] No

### Does this introduce an unwanted change on infrastructure? Check terraform plan execution result

- [ ] Yes
- [x] No

### Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->

---

### If PR is partially applied, why? (reserved to mantainers)

<!--- Describe the blocking cause -->
