### PR TITLE
[IOPAY-135] Add custom domains for iopay and iopayportal

### DIFF
--- a/prod/westeurope/common/cdn/cdn_endpoint_iopay_custom_domain/terragrunt.hcl
+++ b/prod/westeurope/common/cdn/cdn_endpoint_iopay_custom_domain/terragrunt.hcl
@@ -1,0 +1,40 @@
+dependency "cdn_profile" {
+  config_path = "../cdn_profile"
+}
+
+dependency "cdn_endpoint_iopay" {
+  config_path = "../cdn_endpoint_iopay"
+}
+
+# Common
+dependency "resource_group" {
+  config_path = "../../resource_group"
+}
+
+# Infra
+dependency "dns_zone" {
+  config_path = "../../../infra/public_dns_zone"
+}
+
+# Include all settings from the root terragrunt.hcl file
+include {
+  path = find_in_parent_folders()
+}
+
+terraform {
+  source = "git::git@github.com:pagopa/io-infrastructure-modules-new.git//azurerm_cdn_endpoint_custom_domain?ref=v3.0.3"
+}
+
+inputs = {
+  name                = "paga"
+  resource_group_name = dependency.resource_group.outputs.resource_name
+  dns_zone = {
+    name                = dependency.dns_zone.outputs.name
+    resource_group_name = dependency.dns_zone.outputs.resource_group_name
+  }
+  profile_name = dependency.cdn_profile.outputs.resource_name
+  endpoint = {
+    name     = dependency.cdn_endpoint_iopay.outputs.resource_name
+    hostname = dependency.cdn_endpoint_iopay.outputs.hostname
+  }
+}

--- a/prod/westeurope/common/cdn/cdn_endpoint_iopayportal_custom_domain/terragrunt.hcl
+++ b/prod/westeurope/common/cdn/cdn_endpoint_iopayportal_custom_domain/terragrunt.hcl
@@ -1,0 +1,40 @@
+dependency "cdn_profile" {
+  config_path = "../cdn_profile"
+}
+
+dependency "cdn_endpoint_iopayportal" {
+  config_path = "../cdn_endpoint_iopayportal"
+}
+
+# Common
+dependency "resource_group" {
+  config_path = "../../resource_group"
+}
+
+# Infra
+dependency "dns_zone" {
+  config_path = "../../../infra/public_dns_zone"
+}
+
+# Include all settings from the root terragrunt.hcl file
+include {
+  path = find_in_parent_folders()
+}
+
+terraform {
+  source = "git::git@github.com:pagopa/io-infrastructure-modules-new.git//azurerm_cdn_endpoint_custom_domain?ref=v3.0.3"
+}
+
+inputs = {
+  name                = "paga"
+  resource_group_name = dependency.resource_group.outputs.resource_name
+  dns_zone = {
+    name                = dependency.dns_zone.outputs.name
+    resource_group_name = dependency.dns_zone.outputs.resource_group_name
+  }
+  profile_name = dependency.cdn_profile.outputs.resource_name
+  endpoint = {
+    name     = dependency.cdn_endpoint_iopayportal.outputs.resource_name
+    hostname = dependency.cdn_endpoint_iopayportal.outputs.hostname
+  }
+}


### PR DESCRIPTION
### Description

The PR adds custom domains for _io-pay_ and _io-pay-portal_.

### List of changes

- custom domain for _io-pay_: `paga.io.italia.it`
- custom domain for _io-pay-portal:_ `checkout.io.italia.it`

### Motivation and context

<!--- Why is this change required? What problem does it solve? -->

### Type of changes

- [ ] Add new resources
- [ ] Update configuration to existing resources
- [ ] Remove existing resources

### Does this introduce a change to production resources with possible user impact?

- [ ] Yes, users may be impacted applying this change
- [ ] No

### Does this introduce an unwanted change on infrastructure? Check terraform plan execution result

- [ ] Yes
- [ ] No

### Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->

---

### If PR is partially applied, why? (reserved to mantainers)

<!--- Describe the blocking cause -->
