### PR TITLE
[IOPAY-111] Add apim config to support xpay flow

### DIFF
--- a/prod/westeurope/internal/api/apim/api_management_api_io_payportal/api/swagger.json.tmpl
+++ b/prod/westeurope/internal/api/apim/api_management_api_io_payportal/api/swagger.json.tmpl
@@ -313,6 +313,64 @@
           }
         }
       }
+    },
+    "/transactions/xpay/{id}": {
+      "get": {
+        "operationId": "GetTransactionsXpay",
+        "description": "API to support xpay flow",
+        "produces": [
+          "text/html"
+        ],
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "description": "transaction id",
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "html with redirect io-pay"
+          },
+          "400": {
+            "description": "Bad request"
+          },
+          "500": {
+            "description": "generic error"
+          }
+        }
+      }
+    },
+    "/transactions/xpay/verification/{id}": {
+      "get": {
+        "operationId": "GetTransactionsXpayVerification",
+        "description": "API to support xpay verification flow",
+        "produces": [
+          "text/html"
+        ],
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "description": "transaction id",
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "html with redirect io-pay"
+          },
+          "400": {
+            "description": "Bad request"
+          },
+          "500": {
+            "description": "generic error"
+          }
+        }
+      }
     }
   },
   "definitions": {

--- a/prod/westeurope/internal/api/apim/api_management_api_io_payportal/get_transactions_xpay_policy/policy.xml
+++ b/prod/westeurope/internal/api/apim/api_management_api_io_payportal/get_transactions_xpay_policy/policy.xml
@@ -1,0 +1,30 @@
+<policies>
+    <inbound>
+        <set-backend-service base-url="{{io-fn-pay-portal-url}}/api/v1" />
+        <set-header name="x-functions-key" exists-action="override">
+            <value>{{io-fn-pay-portal-key}}</value>
+        </set-header>
+        <rate-limit-by-key calls="20" renewal-period="30" counter-key="@(context.Request.IpAddress)" />
+        <cors>
+            <allowed-origins>
+                <origin>*</origin>
+            </allowed-origins>
+            <allowed-methods>
+                <method>GET</method>
+                <method>OPTIONS</method>
+            </allowed-methods>
+            <allowed-headers>
+                <header>Content-Type</header>
+            </allowed-headers>
+        </cors>
+    </inbound>
+    <outbound>
+        <base />
+    </outbound>
+    <backend>
+        <base />
+    </backend>
+    <on-error>
+        <base />
+    </on-error>
+</policies>

--- a/prod/westeurope/internal/api/apim/api_management_api_io_payportal/get_transactions_xpay_policy/terragrunt.hcl
+++ b/prod/westeurope/internal/api/apim/api_management_api_io_payportal/get_transactions_xpay_policy/terragrunt.hcl
@@ -1,0 +1,27 @@
+dependency "api_management" {
+  config_path = "../../api_management"
+}
+
+# Internal
+dependency "resource_group" {
+  config_path = "../../../../resource_group"
+}
+
+# Include all settings from the root terragrunt.hcl file
+include {
+  path = find_in_parent_folders()
+}
+
+terraform {
+  source = "git::git@github.com:pagopa/io-infrastructure-modules-new.git//azurerm_api_management_api_operation_policy?ref=v3.0.5"
+}
+
+inputs = {
+  api_name            = "io-payportal-api"
+  resource_group_name = dependency.resource_group.outputs.resource_name
+  api_management_name = dependency.api_management.outputs.name
+  operation_id        = "GetTransactionsXpay"
+
+  xml_content = file("policy.xml")
+
+}

--- a/prod/westeurope/internal/api/apim/api_management_api_io_payportal/get_transactions_xpay_verification_policy/policy.xml
+++ b/prod/westeurope/internal/api/apim/api_management_api_io_payportal/get_transactions_xpay_verification_policy/policy.xml
@@ -1,0 +1,30 @@
+<policies>
+    <inbound>
+        <set-backend-service base-url="{{io-fn-pay-portal-url}}/api/v1" />
+        <set-header name="x-functions-key" exists-action="override">
+            <value>{{io-fn-pay-portal-key}}</value>
+        </set-header>
+        <rate-limit-by-key calls="20" renewal-period="30" counter-key="@(context.Request.IpAddress)" />
+        <cors>
+            <allowed-origins>
+                <origin>*</origin>
+            </allowed-origins>
+            <allowed-methods>
+                <method>GET</method>
+                <method>OPTIONS</method>
+            </allowed-methods>
+            <allowed-headers>
+                <header>Content-Type</header>
+            </allowed-headers>
+        </cors>
+    </inbound>
+    <outbound>
+        <base />
+    </outbound>
+    <backend>
+        <base />
+    </backend>
+    <on-error>
+        <base />
+    </on-error>
+</policies>

--- a/prod/westeurope/internal/api/apim/api_management_api_io_payportal/get_transactions_xpay_verification_policy/terragrunt.hcl
+++ b/prod/westeurope/internal/api/apim/api_management_api_io_payportal/get_transactions_xpay_verification_policy/terragrunt.hcl
@@ -1,0 +1,27 @@
+dependency "api_management" {
+  config_path = "../../api_management"
+}
+
+# Internal
+dependency "resource_group" {
+  config_path = "../../../../resource_group"
+}
+
+# Include all settings from the root terragrunt.hcl file
+include {
+  path = find_in_parent_folders()
+}
+
+terraform {
+  source = "git::git@github.com:pagopa/io-infrastructure-modules-new.git//azurerm_api_management_api_operation_policy?ref=v3.0.5"
+}
+
+inputs = {
+  api_name            = "io-payportal-api"
+  resource_group_name = dependency.resource_group.outputs.resource_name
+  api_management_name = dependency.api_management.outputs.name
+  operation_id        = "GetTransactionsXpayVerification"
+
+  xml_content = file("policy.xml")
+
+}


### PR DESCRIPTION
### List of changes

- add new api `/transactions/xpay/{id}` and `/transactions/xpay/verification/{id}` in `api_management_api_io_payportal/api/swagger.json.tmpl`;
- add new policy for `/transactions/xpay/{id}`;
- add new policy for `/transactions/xpay/verification/{id}`;

### Motivation and context

The purpose of this PR is to configure two new API to support payments in [io-pay](https://github.com/pagopa/io-pay) with Xpay cards ([io-pay xpay flow](https://pagopa.atlassian.net/wiki/spaces/I/pages/84934691/Analisi+tecnica+IO-Pay#4.-IO-PAY---focus-flusso-3ds2-(nexi))). 

### Type of changes

- [ ] Add new resources
- [x] Update configuration to existing resources
- [ ] Remove existing resources

### Does this introduce a change to production resources with possible user impact?

- [ ] Yes, users may be impacted applying this change
- [x] No

### Does this introduce an unwanted change on infrastructure? Check terraform plan execution result

- [ ] Yes
- [ ] No

### Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->

---

### If PR is partially applied, why? (reserved to mantainers)

<!--- Describe the blocking cause -->
