### PR TITLE
reduce canary users from ~10% to ~6,25%

### DIFF
--- a/prod/westeurope/notifications/functions_pushnotif/function_app/terragrunt.hcl
+++ b/prod/westeurope/notifications/functions_pushnotif/function_app/terragrunt.hcl
@@ -107,9 +107,9 @@ inputs = {
     BETA_USERS_STORAGE_CONNECTION_STRING  = dependency.storage_beta_test_users.outputs.primary_connection_string
     BETA_USERS_TABLE_NAME                 = dependency.storage_beta_test_users_table_notificationhub.outputs.name
     
-    # Matches a 64-characters hex string ending with "0" or with "n1" (where n is a character from 0 to 7 )
-    CANARY_USERS_REGEX                    = "^([(0-9)|(a-f)|(A-F)]{63}0)|([(0-9)|(a-f)|(A-F)]{62}[(0-7)]{1}1)$"
-    # ------------------------------------
+    # Takes ~6,25% of users
+    CANARY_USERS_REGEX                    = "^([(0-9)|(a-f)|(A-F)]{63}0)$"
+    # ------------------------------------------------------------------------------
 
     // Disable functions
     "AzureWebJobs.HandleNHNotificationCall.Disabled" = "0"

--- a/prod/westeurope/notifications/functions_pushnotif/function_app_slot_staging/terragrunt.hcl
+++ b/prod/westeurope/notifications/functions_pushnotif/function_app_slot_staging/terragrunt.hcl
@@ -95,7 +95,7 @@ inputs = {
 
     APPINSIGHTS_SAMPLING_PERCENTAGE = 5
 
-    # ------------------------------------
+    # ------------------------------------------------------------------------------
     # Variable used during transition to new NH management
 
     # Possible values : "none" | "all" | "beta" | "canary"
@@ -103,9 +103,9 @@ inputs = {
     BETA_USERS_STORAGE_CONNECTION_STRING  = dependency.storage_beta_test_users.outputs.primary_connection_string
     BETA_USERS_TABLE_NAME                 = dependency.storage_beta_test_users_table_notificationhub.outputs.name
     
-    # Matches a 64-characters hex string ending with "0" or with "n1" (where n is a character from 0 to 7 )
-    CANARY_USERS_REGEX                    = "^([(0-9)|(a-f)|(A-F)]{63}0)|([(0-9)|(a-f)|(A-F)]{62}[(0-7)]{1}1)$"
-    # ------------------------------------
+    # Takes ~6,25% of users
+    CANARY_USERS_REGEX                    = "^([(0-9)|(a-f)|(A-F)]{63}0)$"
+    # ------------------------------------------------------------------------------
 
     // Disable functions
     "AzureWebJobs.HandleNHNotificationCall.Disabled" = "1"


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

### List of changes

<!--- Describe your changes in detail -->
Changed canary regex to match lower percentage of users (6,25%)

### Motivation and context

<!--- Why is this change required? What problem does it solve? -->
Reduce percentage of canary users from 10% to 6,25% (estimated)

### Type of changes

- [ ] Add new resources
- [x] Update configuration to existing resources
- [ ] Remove existing resources

### Does this introduce a change to production resources with possible user impact?

- [ ] Yes, users may be impacted applying this change
- [x] No

### Does this introduce an unwanted change on infrastructure? Check terraform plan execution result

- [ ] Yes
- [x] No

### Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->

---

### If PR is partially applied, why? (reserved to mantainers)

<!--- Describe the blocking cause -->
