### PR TITLE
[IOPAY-111] New env to support xpay redirect to io-pay

### DIFF
--- a/prod/westeurope/internal/api/functions_iopayportal/function_app/terragrunt.hcl
+++ b/prod/westeurope/internal/api/functions_iopayportal/function_app/terragrunt.hcl
@@ -100,7 +100,8 @@ inputs = {
     WEBSITE_CONTENTSHARE = "io-p-func-iopayportal-content"
 
     IO_PAY_CHALLENGE_RESUME_URL = "https://io-p-cdnendpoint-iopay.azureedge.net/response.html?id=idTransaction"
-    IO_PAY_ORIGIN = "https://io-p-cdnendpoint-iopay.azureedge.net"
+    IO_PAY_ORIGIN               = "https://io-p-cdnendpoint-iopay.azureedge.net"
+    IO_PAY_XPAY_REDIRECT        = "https://io-p-cdnendpoint-iopay.azureedge.net//response.html?id=_id_&resumeType=_resumeType_&_queryParams_"
   }
 
   app_settings_secrets = {

--- a/prod/westeurope/internal/api/functions_iopayportal/function_app_slot_staging/terragrunt.hcl
+++ b/prod/westeurope/internal/api/functions_iopayportal/function_app_slot_staging/terragrunt.hcl
@@ -107,7 +107,8 @@ inputs = {
     WEBSITE_CONTENTSHARE = "staging-content"
 
     IO_PAY_CHALLENGE_RESUME_URL = "https://io-p-cdnendpoint-iopay.azureedge.net//response.html?id=idTransaction"
-    IO_PAY_ORIGIN = "https://io-p-cdnendpoint-iopay.azureedge.net"
+    IO_PAY_ORIGIN               = "https://io-p-cdnendpoint-iopay.azureedge.net"
+    IO_PAY_XPAY_REDIRECT        = "https://io-p-cdnendpoint-iopay.azureedge.net//response.html?id=_id_&resumeType=_resumeType_&_queryParams_"
   }
 
   app_settings_secrets = {


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

### List of changes

- New env variable `IO_PAY_XPAY_REDIRECT` to support _xpay_ redirect to _io-pay_.

<!--- Describe your changes in detail -->

### Motivation and context

The new variable `IO_PAY_XPAY_REDIRECT` is used by `io-pay-portal` to construct the return url to _io-pay_ from  _xpay_ .

<!--- Why is this change required? What problem does it solve? -->

### Type of changes

- [ ] Add new resources
- [x] Update configuration to existing resources
- [ ] Remove existing resources

### Does this introduce a change to production resources with possible user impact?

- [ ] Yes, users may be impacted applying this change
- [ ] No

### Does this introduce an unwanted change on infrastructure? Check terraform plan execution result

- [ ] Yes
- [ ] No

### Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->

---

### If PR is partially applied, why? (reserved to mantainers)

<!--- Describe the blocking cause -->
