### PR TITLE
[IOPAY-97] Add new env for recaptcha secret - pay portal

### DIFF
--- a/prod/westeurope/internal/api/functions_iopayportal/function_app/terragrunt.hcl
+++ b/prod/westeurope/internal/api/functions_iopayportal/function_app/terragrunt.hcl
@@ -106,8 +106,8 @@ inputs = {
   app_settings_secrets = {
     key_vault_id = dependency.key_vault.outputs.id
     map = {
-      RECAPTCHA_SECRET               = "newsletter-GOOGLE-RECAPTCHA-SECRET"
-      IO_PAY_PORTAL_RECAPTCHA_SECRET = "iopayportal-GOOGLE-RECAPTCHA-SECRET"
+      RECAPTCHA_SECRET            = "newsletter-GOOGLE-RECAPTCHA-SECRET"
+      PAY_PORTAL_RECAPTCHA_SECRET = "payportal-GOOGLE-RECAPTCHA-SECRET"
 
       # Mailup account:
       MAILUP_CLIENT_ID = "newsletter-MAILUP-CLIENT-ID"

--- a/prod/westeurope/internal/api/functions_iopayportal/function_app/terragrunt.hcl
+++ b/prod/westeurope/internal/api/functions_iopayportal/function_app/terragrunt.hcl
@@ -106,7 +106,9 @@ inputs = {
   app_settings_secrets = {
     key_vault_id = dependency.key_vault.outputs.id
     map = {
-      RECAPTCHA_SECRET = "newsletter-GOOGLE-RECAPTCHA-SECRET"
+      RECAPTCHA_SECRET               = "newsletter-GOOGLE-RECAPTCHA-SECRET"
+      IO_PAY_PORTAL_RECAPTCHA_SECRET = "iopayportal-GOOGLE-RECAPTCHA-SECRET"
+
       # Mailup account:
       MAILUP_CLIENT_ID = "newsletter-MAILUP-CLIENT-ID"
       MAILUP_SECRET    = "newsletter-MAILUP-SECRET"

--- a/prod/westeurope/internal/api/functions_iopayportal/function_app_slot_staging/terragrunt.hcl
+++ b/prod/westeurope/internal/api/functions_iopayportal/function_app_slot_staging/terragrunt.hcl
@@ -113,7 +113,9 @@ inputs = {
   app_settings_secrets = {
     key_vault_id = dependency.key_vault.outputs.id
     map = {
-      RECAPTCHA_SECRET = "newsletter-GOOGLE-RECAPTCHA-SECRET"
+      RECAPTCHA_SECRET               = "newsletter-GOOGLE-RECAPTCHA-SECRET"
+      IO_PAY_PORTAL_RECAPTCHA_SECRET = "iopayportal-GOOGLE-RECAPTCHA-SECRET"
+      
       # Mailup account:
       MAILUP_CLIENT_ID = "newsletter-MAILUP-CLIENT-ID"
       MAILUP_SECRET    = "newsletter-MAILUP-SECRET"

--- a/prod/westeurope/internal/api/functions_iopayportal/function_app_slot_staging/terragrunt.hcl
+++ b/prod/westeurope/internal/api/functions_iopayportal/function_app_slot_staging/terragrunt.hcl
@@ -113,8 +113,8 @@ inputs = {
   app_settings_secrets = {
     key_vault_id = dependency.key_vault.outputs.id
     map = {
-      RECAPTCHA_SECRET               = "newsletter-GOOGLE-RECAPTCHA-SECRET"
-      IO_PAY_PORTAL_RECAPTCHA_SECRET = "iopayportal-GOOGLE-RECAPTCHA-SECRET"
+      RECAPTCHA_SECRET            = "newsletter-GOOGLE-RECAPTCHA-SECRET"
+      PAY_PORTAL_RECAPTCHA_SECRET = "payportal-GOOGLE-RECAPTCHA-SECRET"
       
       # Mailup account:
       MAILUP_CLIENT_ID = "newsletter-MAILUP-CLIENT-ID"


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

### List of changes

-  Add new env variable `PAY_PORTAL_RECAPTCHA_SECRET` from secrets;

### Motivation and context

This new variable is necessary to differentiate the Recaptcha Google secret  for newsletters (_io.italia.it_ and _www.pagopa.gov.it_) and the one used by the payment portal (_paga.io.italia.it_).
### Type of changes

- [ ] Add new resources
- [x] Update configuration to existing resources
- [ ] Remove existing resources

### Does this introduce a change to production resources with possible user impact?

- [ ] Yes, users may be impacted applying this change
- [n] No

### Does this introduce an unwanted change on infrastructure? Check terraform plan execution result

- [ ] Yes
- [ ] No

### Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->

---

### If PR is partially applied, why? (reserved to mantainers)

<!--- Describe the blocking cause -->
