### PR TITLE
[IOPAY-173] Update checkout.pagopa.gov.it origin

### DIFF
--- a/prod/westeurope/internal/api/apim/api_management_api_io_payportal/api/policy.xml
+++ b/prod/westeurope/internal/api/apim/api_management_api_io_payportal/api/policy.xml
@@ -9,7 +9,8 @@
     <cors>
       <allowed-origins>
         <origin>https://io-p-cdnendpoint-iopayportal.azureedge.net/</origin>
-        <origin>https://io-p-cdnendpoint-iopay.azureedge.net/</origin>
+        <origin>https://paga.io.italia.it/</origin>
+        <origin>https://checkout.pagopa.gov.it/</origin>
         <origin>https://io.italia.it/</origin>
         <origin>https://www.pagopa.gov.it/</origin>
       </allowed-origins>

--- a/prod/westeurope/internal/api/functions_iopayportal/function_app/terragrunt.hcl
+++ b/prod/westeurope/internal/api/functions_iopayportal/function_app/terragrunt.hcl
@@ -58,7 +58,7 @@ inputs = {
 
   runtime_version = "~3"
 
-  pre_warmed_instance_count = 2
+  pre_warmed_instance_count = 1
 
   application_insights_instrumentation_key = dependency.application_insights.outputs.instrumentation_key
 

--- a/prod/westeurope/internal/api/functions_iopayportal/function_app/terragrunt.hcl
+++ b/prod/westeurope/internal/api/functions_iopayportal/function_app/terragrunt.hcl
@@ -99,9 +99,9 @@ inputs = {
     # https://github.com/terraform-providers/terraform-provider-azurerm/issues/10499
     WEBSITE_CONTENTSHARE = "io-p-func-iopayportal-content"
 
-    IO_PAY_CHALLENGE_RESUME_URL = "https://io-p-cdnendpoint-iopay.azureedge.net/response.html?id=idTransaction"
-    IO_PAY_ORIGIN               = "https://io-p-cdnendpoint-iopay.azureedge.net"
-    IO_PAY_XPAY_REDIRECT        = "https://io-p-cdnendpoint-iopay.azureedge.net//response.html?id=_id_&resumeType=_resumeType_&_queryParams_"
+    IO_PAY_CHALLENGE_RESUME_URL = "https://checkout.pagopa.gov.it/response.html?id=idTransaction"
+    IO_PAY_ORIGIN               = "https://checkout.pagopa.gov.it"
+    IO_PAY_XPAY_REDIRECT        = "https://checkout.pagopa.gov.it/response.html?id=_id_&resumeType=_resumeType_&_queryParams_"
   }
 
   app_settings_secrets = {

--- a/prod/westeurope/internal/api/functions_iopayportal/function_app_slot_staging/terragrunt.hcl
+++ b/prod/westeurope/internal/api/functions_iopayportal/function_app_slot_staging/terragrunt.hcl
@@ -106,9 +106,9 @@ inputs = {
     # https://github.com/terraform-providers/terraform-provider-azurerm/issues/10499
     WEBSITE_CONTENTSHARE = "staging-content"
 
-    IO_PAY_CHALLENGE_RESUME_URL = "https://io-p-cdnendpoint-iopay.azureedge.net//response.html?id=idTransaction"
-    IO_PAY_ORIGIN               = "https://io-p-cdnendpoint-iopay.azureedge.net"
-    IO_PAY_XPAY_REDIRECT        = "https://io-p-cdnendpoint-iopay.azureedge.net//response.html?id=_id_&resumeType=_resumeType_&_queryParams_"
+    IO_PAY_CHALLENGE_RESUME_URL = "https://checkout.pagopa.gov.it/response.html?id=idTransaction"
+    IO_PAY_ORIGIN               = "https://checkout.pagopa.gov.it"
+    IO_PAY_XPAY_REDIRECT        = "https://checkout.pagopa.gov.it/response.html?id=_id_&resumeType=_resumeType_&_queryParams_"
   }
 
   app_settings_secrets = {


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

### List of changes

- Updated origins of _apim_io_pay_portal_ with:
  - https://paga.io.italia.it
  - https://checkout.pagopa.gov.it
- Update app setting of io-functions_pay_portal:
  - `IO_PAY_CHALLENGE_RESUME_URL`
  - `IO_PAY_ORIGIN`
  - `IO_PAY_XPAY_REDIRECT`
  
### Motivation and context

The goal of this PR is to align allowed origin and url for _3ds2 payment flow_ to production values.

### Type of changes

- [ ] Add new resources
- [x] Update configuration to existing resources
- [ ] Remove existing resources

### Does this introduce a change to production resources with possible user impact?

- [ ] Yes, users may be impacted applying this change
- [ ] No

### Does this introduce an unwanted change on infrastructure? Check terraform plan execution result

- [ ] Yes
- [ ] No

### Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->

---

### If PR is partially applied, why? (reserved to mantainers)

<!--- Describe the blocking cause -->
