### PR TITLE
[IP-146] Add env variable to prod and staging

### DIFF
--- a/prod/westeurope/notifications/functions_pushnotif/function_app/terragrunt.hcl
+++ b/prod/westeurope/notifications/functions_pushnotif/function_app/terragrunt.hcl
@@ -121,17 +121,14 @@ inputs = {
     AZURE_NH_HUB_NAME = dependency.notification_hub.outputs.name
 
     # Endpoint for the test notification hub namespace
-    NH1_PARTITION_REGEX=^[0-3]
-    NH1_NAME=dependency.notification_hub_partition_1.name
-
-    NH2_PARTITION_REGEX=^[4-7]
-    NH2_NAME=dependency.notification_hub_partition_2.name
-
-    NH3_PARTITION_REGEX=^[8-b]
-    NH3_NAME=dependency.notification_hub_partition_3.name
-
-    NH4_PARTITION_REGEX=^[c-f]
-    NH4_NAME=dependency.notification_hub_partition_4.name
+    NH1_PARTITION_REGEX = "^[0-3]"
+    NH1_NAME            = dependency.notification_hub_partition_1.name
+    NH2_PARTITION_REGEX = "^[4-7]"
+    NH2_NAME            = dependency.notification_hub_partition_2.name
+    NH3_PARTITION_REGEX = "^[8-b]"
+    NH3_NAME            = dependency.notification_hub_partition_3.name
+    NH4_PARTITION_REGEX = "^[c-f]"
+    NH4_NAME            = dependency.notification_hub_partition_4.name
     # ------------------------------------------------------------------------------
 
 
@@ -159,10 +156,10 @@ inputs = {
     key_vault_id = dependency.key_vault.outputs.id
     map = {
       AZURE_NH_ENDPOINT = "common-AZURE-NH-ENDPOINT"
-      NH1_ENDPOINT = "${dependency.notification_hub_partition_1.name}-AZURE-NH-ENDPOINT"
-      NH2_ENDPOINT = "${dependency.notification_hub_partition_2.name}-AZURE-NH-ENDPOINT"
-      NH3_ENDPOINT = "${dependency.notification_hub_partition_3.name}-AZURE-NH-ENDPOINT"
-      NH4_ENDPOINT = "${dependency.notification_hub_partition_4.name}-AZURE-NH-ENDPOINT"
+      NH1_ENDPOINT      = "${dependency.notification_hub_partition_1.name}-AZURE-NH-ENDPOINT"
+      NH2_ENDPOINT      = "${dependency.notification_hub_partition_2.name}-AZURE-NH-ENDPOINT"
+      NH3_ENDPOINT      = "${dependency.notification_hub_partition_3.name}-AZURE-NH-ENDPOINT"
+      NH4_ENDPOINT      = "${dependency.notification_hub_partition_4.name}-AZURE-NH-ENDPOINT"
     }
   }
 

--- a/prod/westeurope/notifications/functions_pushnotif/function_app/terragrunt.hcl
+++ b/prod/westeurope/notifications/functions_pushnotif/function_app/terragrunt.hcl
@@ -122,13 +122,13 @@ inputs = {
 
     # Endpoint for the test notification hub namespace
     NH1_PARTITION_REGEX = "^[0-3]"
-    NH1_NAME            = dependency.notification_hub_partition_1.name
+    NH1_NAME            = dependency.notification_hub_partition_1.outputs.name
     NH2_PARTITION_REGEX = "^[4-7]"
-    NH2_NAME            = dependency.notification_hub_partition_2.name
+    NH2_NAME            = dependency.notification_hub_partition_2.outputs.name
     NH3_PARTITION_REGEX = "^[8-b]"
-    NH3_NAME            = dependency.notification_hub_partition_3.name
+    NH3_NAME            = dependency.notification_hub_partition_3.outputs.name
     NH4_PARTITION_REGEX = "^[c-f]"
-    NH4_NAME            = dependency.notification_hub_partition_4.name
+    NH4_NAME            = dependency.notification_hub_partition_4.outputs.name
     # ------------------------------------------------------------------------------
 
 
@@ -156,10 +156,10 @@ inputs = {
     key_vault_id = dependency.key_vault.outputs.id
     map = {
       AZURE_NH_ENDPOINT = "common-AZURE-NH-ENDPOINT"
-      NH1_ENDPOINT      = "${dependency.notification_hub_partition_1.name}-AZURE-NH-ENDPOINT"
-      NH2_ENDPOINT      = "${dependency.notification_hub_partition_2.name}-AZURE-NH-ENDPOINT"
-      NH3_ENDPOINT      = "${dependency.notification_hub_partition_3.name}-AZURE-NH-ENDPOINT"
-      NH4_ENDPOINT      = "${dependency.notification_hub_partition_4.name}-AZURE-NH-ENDPOINT"
+      NH1_ENDPOINT      = "${dependency.notification_hub_partition_1.outputs.name}-AZURE-NH-ENDPOINT"
+      NH2_ENDPOINT      = "${dependency.notification_hub_partition_2.outputs.name}-AZURE-NH-ENDPOINT"
+      NH3_ENDPOINT      = "${dependency.notification_hub_partition_3.outputs.name}-AZURE-NH-ENDPOINT"
+      NH4_ENDPOINT      = "${dependency.notification_hub_partition_4.outputs.name}-AZURE-NH-ENDPOINT"
     }
   }
 

--- a/prod/westeurope/notifications/functions_pushnotif/function_app/terragrunt.hcl
+++ b/prod/westeurope/notifications/functions_pushnotif/function_app/terragrunt.hcl
@@ -6,8 +6,25 @@ dependency "subnet" {
   config_path = "../subnet"
 }
 
+# Notification Hubs
 dependency "notification_hub" {
   config_path = "../../../common/notification_hub"
+}
+
+dependency "notification_hub_partition_1" {
+  config_path = "../../../common/notification_hub_partition_1"
+}
+
+dependency "notification_hub_partition_2" {
+  config_path = "../../../common/notification_hub_partition_2"
+}
+
+dependency "notification_hub_partition_3" {
+  config_path = "../../../common/notification_hub_partition_3"
+}
+
+dependency "notification_hub_partition_4" {
+  config_path = "../../../common/notification_hub_partition_4"
 }
 
 # Internal
@@ -86,8 +103,6 @@ inputs = {
     FETCH_KEEPALIVE_FREE_SOCKET_TIMEOUT = "30000"
     FETCH_KEEPALIVE_TIMEOUT             = "60000"
 
-    // Endpoint for the test notification hub namespace
-    AZURE_NH_HUB_NAME = dependency.notification_hub.outputs.name
 
     NOTIFICATIONS_QUEUE_NAME                = dependency.storage_notifications_queue_push-notifications.outputs.name
     NOTIFICATIONS_STORAGE_CONNECTION_STRING = dependency.storage_notifications.outputs.primary_connection_string
@@ -99,7 +114,28 @@ inputs = {
 
     APPINSIGHTS_SAMPLING_PERCENTAGE = 5
 
-    # ------------------------------------
+    # ------------------------------------------------------------------------------
+    # Notification Hubs variables
+
+    # Endpoint for the test notification hub namespace
+    AZURE_NH_HUB_NAME = dependency.notification_hub.outputs.name
+
+    # Endpoint for the test notification hub namespace
+    NH1_PARTITION_REGEX=^[0-3]
+    NH1_NAME=dependency.notification_hub_partition_1.name
+
+    NH2_PARTITION_REGEX=^[4-7]
+    NH2_NAME=dependency.notification_hub_partition_2.name
+
+    NH3_PARTITION_REGEX=^[8-b]
+    NH3_NAME=dependency.notification_hub_partition_3.name
+
+    NH4_PARTITION_REGEX=^[c-f]
+    NH4_NAME=dependency.notification_hub_partition_4.name
+    # ------------------------------------------------------------------------------
+
+
+    # ------------------------------------------------------------------------------
     # Variable used during transition to new NH management
 
     # Possible values : "none" | "all" | "beta" | "canary"
@@ -123,6 +159,10 @@ inputs = {
     key_vault_id = dependency.key_vault.outputs.id
     map = {
       AZURE_NH_ENDPOINT = "common-AZURE-NH-ENDPOINT"
+      NH1_ENDPOINT = "${dependency.notification_hub_partition_1.name}-AZURE-NH-ENDPOINT"
+      NH2_ENDPOINT = "${dependency.notification_hub_partition_2.name}-AZURE-NH-ENDPOINT"
+      NH3_ENDPOINT = "${dependency.notification_hub_partition_3.name}-AZURE-NH-ENDPOINT"
+      NH4_ENDPOINT = "${dependency.notification_hub_partition_4.name}-AZURE-NH-ENDPOINT"
     }
   }
 

--- a/prod/westeurope/notifications/functions_pushnotif/function_app/terragrunt.hcl
+++ b/prod/westeurope/notifications/functions_pushnotif/function_app/terragrunt.hcl
@@ -156,10 +156,10 @@ inputs = {
     key_vault_id = dependency.key_vault.outputs.id
     map = {
       AZURE_NH_ENDPOINT = "common-AZURE-NH-ENDPOINT"
-      NH1_ENDPOINT      = "${dependency.notification_hub_partition_1.outputs.name}-AZURE-NH-ENDPOINT"
-      NH2_ENDPOINT      = "${dependency.notification_hub_partition_2.outputs.name}-AZURE-NH-ENDPOINT"
-      NH3_ENDPOINT      = "${dependency.notification_hub_partition_3.outputs.name}-AZURE-NH-ENDPOINT"
-      NH4_ENDPOINT      = "${dependency.notification_hub_partition_4.outputs.name}-AZURE-NH-ENDPOINT"
+      NH1_ENDPOINT      = "common-partition-1-AZURE-NH-ENDPOINT"
+      NH2_ENDPOINT      = "common-partition-2-AZURE-NH-ENDPOINT"
+      NH3_ENDPOINT      = "common-partition-3-AZURE-NH-ENDPOINT"
+      NH4_ENDPOINT      = "common-partition-4-AZURE-NH-ENDPOINT"
     }
   }
 

--- a/prod/westeurope/notifications/functions_pushnotif/function_app_slot_staging/terragrunt.hcl
+++ b/prod/westeurope/notifications/functions_pushnotif/function_app_slot_staging/terragrunt.hcl
@@ -10,8 +10,25 @@ dependency "function_app" {
   config_path = "../function_app"
 }
 
+# Notification Hubs
 dependency "notification_hub" {
   config_path = "../../../common/notification_hub"
+}
+
+dependency "notification_hub_partition_1" {
+  config_path = "../../../common/notification_hub_partition_1"
+}
+
+dependency "notification_hub_partition_2" {
+  config_path = "../../../common/notification_hub_partition_2"
+}
+
+dependency "notification_hub_partition_3" {
+  config_path = "../../../common/notification_hub_partition_3"
+}
+
+dependency "notification_hub_partition_4" {
+  config_path = "../../../common/notification_hub_partition_4"
 }
 
 # Internal
@@ -82,8 +99,6 @@ inputs = {
     FETCH_KEEPALIVE_FREE_SOCKET_TIMEOUT = "30000"
     FETCH_KEEPALIVE_TIMEOUT             = "60000"
 
-    // Endpoint for the test notification hub namespace
-    AZURE_NH_HUB_NAME = dependency.notification_hub.outputs.name
 
     NOTIFICATIONS_QUEUE_NAME                = dependency.storage_notifications_queue_push-notifications.outputs.name
     NOTIFICATIONS_STORAGE_CONNECTION_STRING = dependency.storage_notifications.outputs.primary_connection_string
@@ -94,6 +109,27 @@ inputs = {
     RETRY_ATTEMPT_NUMBER = 10
 
     APPINSIGHTS_SAMPLING_PERCENTAGE = 5
+
+    # ------------------------------------------------------------------------------
+    # Notification Hubs variables
+
+    # Endpoint for the test notification hub namespace
+    AZURE_NH_HUB_NAME = dependency.notification_hub.outputs.name
+
+    # Endpoint for the test notification hub namespace
+    NH1_PARTITION_REGEX=^[0-3]
+    NH1_NAME=dependency.notification_hub_partition_1.name
+
+    NH2_PARTITION_REGEX=^[4-7]
+    NH2_NAME=dependency.notification_hub_partition_2.name
+
+    NH3_PARTITION_REGEX=^[8-b]
+    NH3_NAME=dependency.notification_hub_partition_3.name
+
+    NH4_PARTITION_REGEX=^[c-f]
+    NH4_NAME=dependency.notification_hub_partition_4.name
+    # ------------------------------------------------------------------------------
+
 
     # ------------------------------------------------------------------------------
     # Variable used during transition to new NH management
@@ -119,6 +155,10 @@ inputs = {
     key_vault_id = dependency.key_vault.outputs.id
     map = {
       AZURE_NH_ENDPOINT = "common-AZURE-NH-ENDPOINT"
+      NH1_ENDPOINT = "${dependency.notification_hub_partition_1.name}-AZURE-NH-ENDPOINT"
+      NH2_ENDPOINT = "${dependency.notification_hub_partition_2.name}-AZURE-NH-ENDPOINT"
+      NH3_ENDPOINT = "${dependency.notification_hub_partition_3.name}-AZURE-NH-ENDPOINT"
+      NH4_ENDPOINT = "${dependency.notification_hub_partition_4.name}-AZURE-NH-ENDPOINT"
     }
   }
 

--- a/prod/westeurope/notifications/functions_pushnotif/function_app_slot_staging/terragrunt.hcl
+++ b/prod/westeurope/notifications/functions_pushnotif/function_app_slot_staging/terragrunt.hcl
@@ -152,10 +152,10 @@ inputs = {
     key_vault_id = dependency.key_vault.outputs.id
     map = {
       AZURE_NH_ENDPOINT = "common-AZURE-NH-ENDPOINT"
-      NH1_ENDPOINT      = "${dependency.notification_hub_partition_1.outputs.name}-AZURE-NH-ENDPOINT"
-      NH2_ENDPOINT      = "${dependency.notification_hub_partition_2.outputs.name}-AZURE-NH-ENDPOINT"
-      NH3_ENDPOINT      = "${dependency.notification_hub_partition_3.outputs.name}-AZURE-NH-ENDPOINT"
-      NH4_ENDPOINT      = "${dependency.notification_hub_partition_4.outputs.name}-AZURE-NH-ENDPOINT"
+      NH1_ENDPOINT      = "common-partition-1-AZURE-NH-ENDPOINT"
+      NH2_ENDPOINT      = "common-partition-2-AZURE-NH-ENDPOINT"
+      NH3_ENDPOINT      = "common-partition-3-AZURE-NH-ENDPOINT"
+      NH4_ENDPOINT      = "common-partition-4-AZURE-NH-ENDPOINT"
     }     
   }
 

--- a/prod/westeurope/notifications/functions_pushnotif/function_app_slot_staging/terragrunt.hcl
+++ b/prod/westeurope/notifications/functions_pushnotif/function_app_slot_staging/terragrunt.hcl
@@ -117,17 +117,14 @@ inputs = {
     AZURE_NH_HUB_NAME = dependency.notification_hub.outputs.name
 
     # Endpoint for the test notification hub namespace
-    NH1_PARTITION_REGEX=^[0-3]
-    NH1_NAME=dependency.notification_hub_partition_1.name
-
-    NH2_PARTITION_REGEX=^[4-7]
-    NH2_NAME=dependency.notification_hub_partition_2.name
-
-    NH3_PARTITION_REGEX=^[8-b]
-    NH3_NAME=dependency.notification_hub_partition_3.name
-
-    NH4_PARTITION_REGEX=^[c-f]
-    NH4_NAME=dependency.notification_hub_partition_4.name
+    NH1_PARTITION_REGEX = "^[0-3]"
+    NH1_NAME            = dependency.notification_hub_partition_1.name
+    NH2_PARTITION_REGEX = "^[4-7]"
+    NH2_NAME            = dependency.notification_hub_partition_2.name
+    NH3_PARTITION_REGEX = "^[8-b]"
+    NH3_NAME            = dependency.notification_hub_partition_3.name
+    NH4_PARTITION_REGEX = "^[c-f]"
+    NH4_NAME            = dependency.notification_hub_partition_4.name
     # ------------------------------------------------------------------------------
 
 
@@ -155,11 +152,11 @@ inputs = {
     key_vault_id = dependency.key_vault.outputs.id
     map = {
       AZURE_NH_ENDPOINT = "common-AZURE-NH-ENDPOINT"
-      NH1_ENDPOINT = "${dependency.notification_hub_partition_1.name}-AZURE-NH-ENDPOINT"
-      NH2_ENDPOINT = "${dependency.notification_hub_partition_2.name}-AZURE-NH-ENDPOINT"
-      NH3_ENDPOINT = "${dependency.notification_hub_partition_3.name}-AZURE-NH-ENDPOINT"
-      NH4_ENDPOINT = "${dependency.notification_hub_partition_4.name}-AZURE-NH-ENDPOINT"
-    }
+      NH1_ENDPOINT      = "${dependency.notification_hub_partition_1.name}-AZURE-NH-ENDPOINT"
+      NH2_ENDPOINT      = "${dependency.notification_hub_partition_2.name}-AZURE-NH-ENDPOINT"
+      NH3_ENDPOINT      = "${dependency.notification_hub_partition_3.name}-AZURE-NH-ENDPOINT"
+      NH4_ENDPOINT      = "${dependency.notification_hub_partition_4.name}-AZURE-NH-ENDPOINT"
+    }     
   }
 
   allowed_subnets = [

--- a/prod/westeurope/notifications/functions_pushnotif/function_app_slot_staging/terragrunt.hcl
+++ b/prod/westeurope/notifications/functions_pushnotif/function_app_slot_staging/terragrunt.hcl
@@ -118,13 +118,13 @@ inputs = {
 
     # Endpoint for the test notification hub namespace
     NH1_PARTITION_REGEX = "^[0-3]"
-    NH1_NAME            = dependency.notification_hub_partition_1.name
+    NH1_NAME            = dependency.notification_hub_partition_1.outputs.name
     NH2_PARTITION_REGEX = "^[4-7]"
-    NH2_NAME            = dependency.notification_hub_partition_2.name
+    NH2_NAME            = dependency.notification_hub_partition_2.outputs.name
     NH3_PARTITION_REGEX = "^[8-b]"
-    NH3_NAME            = dependency.notification_hub_partition_3.name
+    NH3_NAME            = dependency.notification_hub_partition_3.outputs.name
     NH4_PARTITION_REGEX = "^[c-f]"
-    NH4_NAME            = dependency.notification_hub_partition_4.name
+    NH4_NAME            = dependency.notification_hub_partition_4.outputs.name
     # ------------------------------------------------------------------------------
 
 
@@ -152,10 +152,10 @@ inputs = {
     key_vault_id = dependency.key_vault.outputs.id
     map = {
       AZURE_NH_ENDPOINT = "common-AZURE-NH-ENDPOINT"
-      NH1_ENDPOINT      = "${dependency.notification_hub_partition_1.name}-AZURE-NH-ENDPOINT"
-      NH2_ENDPOINT      = "${dependency.notification_hub_partition_2.name}-AZURE-NH-ENDPOINT"
-      NH3_ENDPOINT      = "${dependency.notification_hub_partition_3.name}-AZURE-NH-ENDPOINT"
-      NH4_ENDPOINT      = "${dependency.notification_hub_partition_4.name}-AZURE-NH-ENDPOINT"
+      NH1_ENDPOINT      = "${dependency.notification_hub_partition_1.outputs.name}-AZURE-NH-ENDPOINT"
+      NH2_ENDPOINT      = "${dependency.notification_hub_partition_2.outputs.name}-AZURE-NH-ENDPOINT"
+      NH3_ENDPOINT      = "${dependency.notification_hub_partition_3.outputs.name}-AZURE-NH-ENDPOINT"
+      NH4_ENDPOINT      = "${dependency.notification_hub_partition_4.outputs.name}-AZURE-NH-ENDPOINT"
     }     
   }
 


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

### List of changes

<!--- Describe your changes in detail -->
Addend new NH env variables both to staging and prod _io-functions-pushnotification_

### Motivation and context

<!--- Why is this change required? What problem does it solve? -->
In order to switch to new NH management, we need to add new env variables related to the new Notification Hubs

### Type of changes

- [ ] Add new resources
- [x] Update configuration to existing resources
- [ ] Remove existing resources

### Does this introduce a change to production resources with possible user impact?

- [ ] Yes, users may be impacted applying this change
- [x] No

### Does this introduce an unwanted change on infrastructure? Check terraform plan execution result

- [ ] Yes
- [ ] No

### Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->

---

### If PR is partially applied, why? (reserved to mantainers)

<!--- Describe the blocking cause -->
