### PR TITLE
switch to APNS sandbox in test Notification Hubs

### DIFF
--- a/prod/westeurope/notifications/sandbox/notification_hub-partition-1/terragrunt.hcl
+++ b/prod/westeurope/notifications/sandbox/notification_hub-partition-1/terragrunt.hcl
@@ -22,7 +22,7 @@ inputs = {
   key_vault_id                         = dependency.key_vault.outputs.id
   ntfns_namespace_type                 = "NotificationHub"
   ntfns_sku_name                       = "Standard"
-  ntf_apns_credential_application_mode = "Production"
+  ntf_apns_credential_application_mode = "Sandbox"
 }
 
 

--- a/prod/westeurope/notifications/sandbox/notification_hub/terragrunt.hcl
+++ b/prod/westeurope/notifications/sandbox/notification_hub/terragrunt.hcl
@@ -22,7 +22,7 @@ inputs = {
   key_vault_id                         = dependency.key_vault.outputs.id
   ntfns_namespace_type                 = "NotificationHub"
   ntfns_sku_name                       = "Standard"
-  ntf_apns_credential_application_mode = "Production"
+  ntf_apns_credential_application_mode = "Sandbox"
 }
 
 


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

### List of changes

<!--- Describe your changes in detail -->
- Switch to Sandbox APNS server 

### Motivation and context

<!--- Why is this change required? What problem does it solve? -->
In order to successfully test push notifications in iOS development mode, we need to switch to Sandbox APNS server

### Type of changes

- [ ] Add new resources
- [x] Update configuration to existing resources
- [ ] Remove existing resources

### Does this introduce a change to production resources with possible user impact?

- [ ] Yes, users may be impacted applying this change
- [x] No

### Does this introduce an unwanted change on infrastructure? Check terraform plan execution result

- [ ] Yes
- [ ] No

### Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->

---

### If PR is partially applied, why? (reserved to mantainers)

<!--- Describe the blocking cause -->
