### PR TITLE
[IOPAY-221] Delete cdn origin in apim config

### DIFF
--- a/prod/westeurope/internal/api/apim/api_management_api_io_payportal/api/policy.xml
+++ b/prod/westeurope/internal/api/apim/api_management_api_io_payportal/api/policy.xml
@@ -8,7 +8,6 @@
     <rate-limit-by-key calls="20" renewal-period="30" counter-key="@(context.Request.IpAddress)" />
     <cors>
       <allowed-origins>
-        <origin>https://io-p-cdnendpoint-iopayportal.azureedge.net/</origin>
         <origin>https://paga.io.italia.it/</origin>
         <origin>https://checkout.pagopa.gov.it/</origin>
         <origin>https://io.italia.it/</origin>


### PR DESCRIPTION

### List of changes

- Delete _cdn_ origin in apim _io-pay-portal_ config;

### Motivation and context

The goal of this PR is to delete unnecessary _cdn_ origin in apim _io-pay-portal_ config.

### Type of changes

- [ ] Add new resources
- [x] Update configuration to existing resources
- [ ] Remove existing resources

### Does this introduce a change to production resources with possible user impact?

- [ ] Yes, users may be impacted applying this change
- [x] No

### Does this introduce an unwanted change on infrastructure? Check terraform plan execution result

- [ ] Yes
- [x] No

### Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->

---

### If PR is partially applied, why? (reserved to mantainers)

<!--- Describe the blocking cause -->
