### PR TITLE
Ip 210  add 403 to openapi spec

### DIFF
--- a/prod/westeurope/internal/api/apim/api_management_api_services/swagger.json.tmpl
+++ b/prod/westeurope/internal/api/apim/api_management_api_services/swagger.json.tmpl
@@ -14,7 +14,9 @@
   },
   "host": "${host}",
   "basePath": "/api/v1",
-  "schemes": ["https"],
+  "schemes": [
+    "https"
+  ],
   "security": [
     {
       "SubscriptionKey": []
@@ -640,7 +642,9 @@
           "$ref": "#/definitions/FiscalCode"
         }
       },
-      "required": ["fiscal_code"]
+      "required": [
+        "fiscal_code"
+      ]
     },
     "SubscriptionsFeed": {
       "type": "object",
@@ -655,7 +659,11 @@
           "$ref": "#/definitions/SubscriptionsList"
         }
       },
-      "required": ["dateUTC", "subscriptions", "unsubscriptions"]
+      "required": [
+        "dateUTC",
+        "subscriptions",
+        "unsubscriptions"
+      ]
     },
     "SubscriptionsList": {
       "type": "array",
@@ -717,7 +725,12 @@
     "NotificationChannelStatusValue": {
       "type": "string",
       "description": "The status of a notification (one for each channel).\n\"SENT\": the notification was succesfully sent to the channel (ie. email or push notification)\n\"THROTTLED\": a temporary failure caused a retry during the notification processing;\n  the notification associated with this channel will be delayed for a maximum of 7 days or until the message expires\n\"EXPIRED\": the message expired before the notification could be sent;\n  this means that the maximum message time to live was reached; no notification will be sent to this channel\n\"FAILED\": a permanent failure caused the process to exit with an error, no notification will be sent to this channel",
-      "x-extensible-enum": ["SENT", "THROTTLED", "EXPIRED", "FAILED"],
+      "x-extensible-enum": [
+        "SENT",
+        "THROTTLED",
+        "EXPIRED",
+        "FAILED"
+      ],
       "example": "SENT"
     },
     "MessageResponseWithContent": {
@@ -777,7 +790,9 @@
           "example": "ACCEPTED"
         }
       },
-      "required": ["message"]
+      "required": [
+        "message"
+      ]
     },
     "FiscalCode": {
       "type": "string",
@@ -798,13 +813,21 @@
           "type": "array",
           "items": {
             "type": "string",
-            "x-extensible-enum": ["it_IT", "en_GB", "es_ES", "de_DE", "fr_FR"],
+            "x-extensible-enum": [
+              "it_IT",
+              "en_GB",
+              "es_ES",
+              "de_DE",
+              "fr_FR"
+            ],
             "example": "it_IT"
           },
           "description": "Indicates the User's preferred written or spoken languages in order\nof preference. Generally used for selecting a localized User interface. Valid\nvalues are concatenation of the ISO 639-1 two letter language code, an underscore,\nand the ISO 3166-1 2 letter country code; e.g., 'en_US' specifies the language\nEnglish and country US."
         }
       },
-      "required": ["sender_allowed"]
+      "required": [
+        "sender_allowed"
+      ]
     },
     "Timestamp": {
       "type": "string",
@@ -858,7 +881,10 @@
               "default": false
             }
           },
-          "required": ["amount", "notice_number"]
+          "required": [
+            "amount",
+            "notice_number"
+          ]
         },
         "prescription_data": {
           "type": "object",
@@ -892,7 +918,10 @@
           "$ref": "#/definitions/Timestamp"
         }
       },
-      "required": ["subject", "markdown"]
+      "required": [
+        "subject",
+        "markdown"
+      ]
     },
     "NewMessage": {
       "type": "object",
@@ -918,7 +947,9 @@
           "$ref": "#/definitions/FiscalCode"
         }
       },
-      "required": ["content"]
+      "required": [
+        "content"
+      ]
     },
     "CIDR": {
       "type": "string",
@@ -1210,8 +1241,12 @@
       "x-import": "italia-ts-commons/lib/strings"
     }
   },
-  "consumes": ["application/json"],
-  "produces": ["application/json"],
+  "consumes": [
+    "application/json"
+  ],
+  "produces": [
+    "application/json"
+  ],
   "securityDefinitions": {
     "SubscriptionKey": {
       "type": "apiKey",

--- a/prod/westeurope/internal/api/apim/api_management_api_services/swagger.json.tmpl
+++ b/prod/westeurope/internal/api/apim/api_management_api_services/swagger.json.tmpl
@@ -80,6 +80,9 @@
           "401": {
             "description": "Unauthorized"
           },
+          "403": {
+            "description": "Forbidden."
+          },
           "429": {
             "description": "Too many requests"
           },
@@ -152,6 +155,9 @@
           "401": {
             "description": "Unauthorized"
           },
+          "403": {
+            "description": "Forbidden."
+          },
           "429": {
             "description": "Too many requests"
           },
@@ -208,6 +214,9 @@
           "401": {
             "description": "Unauthorized"
           },
+          "403": {
+            "description": "Forbidden."
+          },
           "404": {
             "description": "No message found for the provided ID.",
             "schema": {
@@ -240,6 +249,9 @@
           },
           "401": {
             "description": "Unauthorized"
+          },
+          "403": {
+            "description": "Forbidden."
           },
           "404": {
             "description": "No user found for the provided fiscal code.",
@@ -283,6 +295,9 @@
           "401": {
             "description": "Unauthorized"
           },
+          "403": {
+            "description": "Forbidden."
+          },
           "404": {
             "description": "No user found for the provided fiscal code.",
             "schema": {
@@ -323,6 +338,9 @@
           },
           "401": {
             "description": "Unauthorized"
+          },
+          "403": {
+            "description": "Forbidden."
           },
           "404": {
             "description": "Subscriptions feed not available yet.",
@@ -371,6 +389,9 @@
           },
           "401": {
             "description": "Unauthorized."
+          },
+          "403": {
+            "description": "Forbidden."
           },
           "429": {
             "description": "Too many requests."

--- a/prod/westeurope/internal/api/apim/api_management_api_services/swagger.json.tmpl
+++ b/prod/westeurope/internal/api/apim/api_management_api_services/swagger.json.tmpl
@@ -1,7 +1,7 @@
 {
   "swagger": "2.0",
   "info": {
-    "version": "1.0.0",
+    "version": "1.15.0",
     "title": "IO SERVICES API",
     "contact": {
       "name": "Digital Transformation Team",
@@ -755,7 +755,7 @@
               "$ref": "#/definitions/MessageContent"
             },
             "sender_service_id": {
-              "type": "string"
+              "$ref": "#/definitions/ServiceId"
             }
           },
           "required": [
@@ -798,7 +798,7 @@
       "type": "string",
       "description": "User's fiscal code.",
       "format": "FiscalCode",
-      "x-import": "italia-ts-commons/lib/strings",
+      "x-import": "@pagopa/ts-commons/lib/strings",
       "example": "SPNDNL80R13C555X"
     },
     "LimitedProfile": {
@@ -833,7 +833,7 @@
       "type": "string",
       "format": "UTCISODateFromString",
       "description": "A date-time field in ISO-8601 format and UTC timezone.",
-      "x-import": "italia-ts-commons/lib/dates",
+      "x-import": "@pagopa/ts-commons/lib/dates",
       "example": "2018-10-13T00:00:00.000Z"
     },
     "TimeToLiveSeconds": {
@@ -906,7 +906,7 @@
               "type": "string",
               "description": "Fiscal code of the Doctor that made the prescription.",
               "format": "FiscalCode",
-              "x-import": "italia-ts-commons/lib/strings",
+              "x-import": "@pagopa/ts-commons/lib/strings",
               "example": "TCNZRO80R13C555Y"
             }
           },
@@ -958,6 +958,69 @@
     },
     "ServicePayload": {
       "description": "A payload used to create/update a service for a user.",
+      "x-one-of": true,
+      "allOf": [
+        {
+          "$ref": "#/definitions/VisibleServicePayload"
+        },
+        {
+          "$ref": "#/definitions/HiddenServicePayload"
+        }
+      ]
+    },
+    "HiddenServicePayload": {
+      "description": "A payload used to create/update a service that is hidden.",
+      "allOf": [
+        {
+          "$ref": "#/definitions/CommonServicePayload"
+        },
+        {
+          "type": "object",
+          "properties": {
+            "is_visible": {
+              "type": "boolean",
+              "default": false,
+              "enum": [
+                false
+              ],
+              "description": "It indicates that service is hidden"
+            },
+            "service_metadata": {
+              "$ref": "#/definitions/ServiceMetadata"
+            }
+          }
+        }
+      ]
+    },
+    "VisibleServicePayload": {
+      "description": "A payload used to create/update a service that appears in the service list.",
+      "allOf": [
+        {
+          "$ref": "#/definitions/CommonServicePayload"
+        },
+        {
+          "type": "object",
+          "properties": {
+            "is_visible": {
+              "type": "boolean",
+              "enum": [
+                true
+              ],
+              "description": "It indicates that service appears in the service list"
+            },
+            "service_metadata": {
+              "$ref": "#/definitions/ServiceMetadata"
+            }
+          },
+          "required": [
+            "is_visible",
+            "service_metadata"
+          ]
+        }
+      ]
+    },
+    "CommonServicePayload": {
+      "description": "Common properties for a ServicePayload",
       "type": "object",
       "properties": {
         "service_name": {
@@ -973,7 +1036,7 @@
           "type": "string",
           "description": "Organization fiscal code.",
           "format": "OrganizationFiscalCode",
-          "x-import": "italia-ts-commons/lib/strings",
+          "x-import": "@pagopa/ts-commons/lib/strings",
           "example": "12345678901"
         },
         "authorized_cidrs": {
@@ -990,14 +1053,6 @@
           "type": "boolean",
           "default": false,
           "description": "When true, messages won't trigger email notifications (only push)."
-        },
-        "is_visible": {
-          "type": "boolean",
-          "default": false,
-          "description": "When true the service appears in the service list, otherwise is hidden."
-        },
-        "service_metadata": {
-          "$ref": "#/definitions/ServiceMetadata"
         }
       },
       "required": [


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

### List of changes

<!--- Describe your changes in detail -->
Update APIM OpenAPI spec for `SERVICE API` to latest development:
* align with previous model refactoring in https://github.com/pagopa/io-infrastructure-live-new/commit/5ae7f2118e2bcbf7a128e4baf12fc5cca1038703
* introduce 403 for APIs that need it

### Motivation and context

<!--- Why is this change required? What problem does it solve? -->
We introduced 403 in https://github.com/pagopa/io-functions-services/pull/125 and we needed to apply same changes to APIM. While doing so, we realized we haven't updated spec for long, so we brought those changes in as well

### Type of changes

- [ ] Add new resources
- [x] Update configuration to existing resources
- [ ] Remove existing resources

### Does this introduce a change to production resources with possible user impact?

- [x] Yes, users may be impacted applying this change
- [ ] No

### Does this introduce an unwanted change on infrastructure? Check terraform plan execution result

- [ ] Yes
- [x] No

### Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->

---

### If PR is partially applied, why? (reserved to mantainers)

<!--- Describe the blocking cause -->
