### PR TITLE
Add configs eucovidcert notify new users

### DIFF
--- a/prod/westeurope/eucovidcert/functions_eucovidcert/function_app/terragrunt.hcl
+++ b/prod/westeurope/eucovidcert/functions_eucovidcert/function_app/terragrunt.hcl
@@ -2,11 +2,19 @@ dependency "resource_group" {
   config_path = "../../resource_group"
 }
 
-# Subnet
 dependency "subnet" {
   config_path = "../subnet"
 }
 
+dependency "storage_account_eucovidcert" {
+  config_path = "../../storage_eucovidcert/account"
+}
+
+dependency "storage_account_eucovidcert_queue_notify-new-profile" {
+  config_path = "../../storage_eucovidcert/queue_notify-new-profile"
+}
+
+# Internal
 dependency "subnet_apimapi" {
   config_path = "../../../internal/api/apim/subnet/"
 }
@@ -21,6 +29,14 @@ dependency "subnet_appbackendl2" {
 
 dependency "functions_services" {
   config_path = "../../../internal/api/functions_services_r3/function_app"
+}
+
+dependency "storage_account_apievents" {
+  config_path = "../../../internal/api/storage_apievents/account"
+}
+
+dependency "storage_account_apievents_queue_eucovidcert-profile-created" {
+  config_path = "../../../internal/api/storage_apievents/queue_eucovidcert-profile-created"
 }
 
 # Common
@@ -90,6 +106,12 @@ inputs = {
     DGC_LOAD_TEST_URL = "https://io-p-fn3-mockdgc.azurewebsites.net"
     DGC_PROD_URL      = "TBD"
     
+    // Events configs
+    EventsQueueStorageConnection              = dependency.storage_account_apievents.outputs.primary_connection_string
+    EUCOVIDCERT_PROFILE_CREATED_QUEUE_NAME    = dependency.storage_account_apievents_queue_eucovidcert-profile-created.outputs.name
+    QueueStorageConnection                    = dependency.storage_account_eucovidcert.outputs.primary_connection_string
+    EUCOVIDCERT_NOTIFY_NEW_PROFILE_QUEUE_NAME = dependency.storage_account_eucovidcert_queue_notify-new-profile.outputs.name
+
     SLOT_TASK_HUBNAME = "ProductionTaskHub"
 
     APPINSIGHTS_SAMPLING_PERCENTAGE = 5

--- a/prod/westeurope/eucovidcert/functions_eucovidcert/function_app/terragrunt.hcl
+++ b/prod/westeurope/eucovidcert/functions_eucovidcert/function_app/terragrunt.hcl
@@ -102,9 +102,9 @@ inputs = {
     DGC_UAT_FISCAL_CODES   = local.testusersvars.locals.test_users_eu_covid_cert_flat
     LOAD_TEST_FISCAL_CODES = local.testusersvars.locals.test_users_internal_load_flat
 
-    DGC_UAT_URL       = "TBD"
+    DGC_UAT_URL       = "https://servizi-pnval.dgc.gov.it"
     DGC_LOAD_TEST_URL = "https://io-p-fn3-mockdgc.azurewebsites.net"
-    DGC_PROD_URL      = "TBD"
+    DGC_PROD_URL      = "https://servizi-pn.dgc.gov.it"
     
     // Events configs
     EventsQueueStorageConnection              = dependency.storage_account_apievents.outputs.primary_connection_string

--- a/prod/westeurope/eucovidcert/functions_eucovidcert/function_app/terragrunt.hcl
+++ b/prod/westeurope/eucovidcert/functions_eucovidcert/function_app/terragrunt.hcl
@@ -19,7 +19,6 @@ dependency "subnet_appbackendl2" {
   config_path = "../../../linux/appbackendl2/subnet"
 }
 
-
 dependency "functions_services" {
   config_path = "../../../internal/api/functions_services_r3/function_app"
 }

--- a/prod/westeurope/eucovidcert/functions_eucovidcert/function_app_slot_staging/terragrunt.hcl
+++ b/prod/westeurope/eucovidcert/functions_eucovidcert/function_app_slot_staging/terragrunt.hcl
@@ -32,9 +32,8 @@ dependency "subnet_fnservices" {
 }
 
 dependency "functions_services" {
-  config_path = "../../../internal/api/functions_services_r3/function_app_slot_staging"
+  config_path = "../../../internal/api/functions_services_r3/function_app"
 }
-
 
 # Common
 dependency "application_insights" {

--- a/prod/westeurope/eucovidcert/functions_eucovidcert/function_app_slot_staging/terragrunt.hcl
+++ b/prod/westeurope/eucovidcert/functions_eucovidcert/function_app_slot_staging/terragrunt.hcl
@@ -11,11 +11,11 @@ dependency "subnet" {
 }
 
 dependency "storage_account_eucovidcert" {
-  config_path = "../../storage_account_eucovidcert/account"
+  config_path = "../../storage_eucovidcert/account"
 }
 
 dependency "storage_account_eucovidcert_queue_notify-new-profile" {
-  config_path = "../../storage_account_eucovidcert/queue_notify-new-profile"
+  config_path = "../../storage_eucovidcert/queue_notify-new-profile"
 }
 
 # Internal
@@ -115,9 +115,9 @@ inputs = {
     DGC_UAT_FISCAL_CODES   = local.testusersvars.locals.test_users_eu_covid_cert_flat
     LOAD_TEST_FISCAL_CODES = local.testusersvars.locals.test_users_internal_load_flat
 
-    DGC_UAT_URL       = "TBD"
+    DGC_UAT_URL       = "https://servizi-pnval.dgc.gov.it"
     DGC_LOAD_TEST_URL = "https://io-p-fn3-mockdgc.azurewebsites.net"
-    DGC_PROD_URL      = "TBD"
+    DGC_PROD_URL      = "https://servizi-pn.dgc.gov.it"
 
     // Events configs
     EventsQueueStorageConnection              = dependency.storage_account_apievents.outputs.primary_connection_string

--- a/prod/westeurope/eucovidcert/functions_eucovidcert/function_app_slot_staging/terragrunt.hcl
+++ b/prod/westeurope/eucovidcert/functions_eucovidcert/function_app_slot_staging/terragrunt.hcl
@@ -6,17 +6,21 @@ dependency "function_app" {
   config_path = "../function_app"
 }
 
-# Subnet
 dependency "subnet" {
   config_path = "../subnet"
 }
 
-dependency "subnet_apimapi" {
-  config_path = "../../../internal/api/apim/subnet/"
+dependency "storage_account_eucovidcert" {
+  config_path = "../../storage_account_eucovidcert/account"
 }
 
-dependency "subnet_azure_devops" {
-  config_path = "../../../common/subnet_azure_devops"
+dependency "storage_account_eucovidcert_queue_notify-new-profile" {
+  config_path = "../../storage_account_eucovidcert/queue_notify-new-profile"
+}
+
+# Internal
+dependency "subnet_apimapi" {
+  config_path = "../../../internal/api/apim/subnet/"
 }
 
 dependency "subnet_appbackendl1" {
@@ -35,6 +39,14 @@ dependency "functions_services" {
   config_path = "../../../internal/api/functions_services_r3/function_app"
 }
 
+dependency "storage_account_apievents" {
+  config_path = "../../../internal/api/storage_apievents/account"
+}
+
+dependency "storage_account_apievents_queue_eucovidcert-profile-created" {
+  config_path = "../../../internal/api/storage_apievents/queue_eucovidcert-profile-created"
+}
+
 # Common
 dependency "application_insights" {
   config_path = "../../../common/application_insights"
@@ -42,6 +54,10 @@ dependency "application_insights" {
 
 dependency "key_vault" {
   config_path = "../../../common/key_vault"
+}
+
+dependency "subnet_azure_devops" {
+  config_path = "../../../common/subnet_azure_devops"
 }
 
 
@@ -102,6 +118,12 @@ inputs = {
     DGC_UAT_URL       = "TBD"
     DGC_LOAD_TEST_URL = "https://io-p-fn3-mockdgc.azurewebsites.net"
     DGC_PROD_URL      = "TBD"
+
+    // Events configs
+    EventsQueueStorageConnection              = dependency.storage_account_apievents.outputs.primary_connection_string
+    EUCOVIDCERT_PROFILE_CREATED_QUEUE_NAME    = dependency.storage_account_apievents_queue_eucovidcert-profile-created.outputs.name
+    QueueStorageConnection                    = dependency.storage_account_eucovidcert.outputs.primary_connection_string
+    EUCOVIDCERT_NOTIFY_NEW_PROFILE_QUEUE_NAME = dependency.storage_account_eucovidcert_queue_notify-new-profile.outputs.name
 
     SLOT_TASK_HUBNAME = "StagingTaskHub"
 

--- a/prod/westeurope/eucovidcert/storage_eucovidcert/account/terragrunt.hcl
+++ b/prod/westeurope/eucovidcert/storage_eucovidcert/account/terragrunt.hcl
@@ -1,0 +1,24 @@
+# Internal
+dependency "resource_group" {
+  config_path = "../../resource_group"
+}
+
+# Include all settings from the root terragrunt.hcl file
+include {
+  path = find_in_parent_folders()
+}
+
+terraform {
+  source = "git::git@github.com:pagopa/io-infrastructure-modules-new.git//azurerm_storage_account?ref=v3.0.3"
+}
+
+inputs = {
+  name                     = "eucovidcert"
+  resource_group_name      = dependency.resource_group.outputs.resource_name
+  account_kind             = "StorageV2"
+  account_tier             = "Standard"
+  account_replication_type = "GRS"
+  access_tier              = "Hot"
+
+  enable_versioning = true
+}

--- a/prod/westeurope/eucovidcert/storage_eucovidcert/queue_notify-new-profile-poison/terragrunt.hcl
+++ b/prod/westeurope/eucovidcert/storage_eucovidcert/queue_notify-new-profile-poison/terragrunt.hcl
@@ -1,0 +1,17 @@
+dependency "storage_account" {
+  config_path = "../account"
+}
+
+# Include all settings from the root terragrunt.hcl file
+include {
+  path = find_in_parent_folders()
+}
+
+terraform {
+  source = "git::git@github.com:pagopa/io-infrastructure-modules-new.git//azurerm_storage_queue?ref=v3.0.3"
+}
+
+inputs = {
+  name                  = "notify-new-profile-poison"
+  storage_account_name  = dependency.storage_account.outputs.resource_name
+}

--- a/prod/westeurope/eucovidcert/storage_eucovidcert/queue_notify-new-profile/terragrunt.hcl
+++ b/prod/westeurope/eucovidcert/storage_eucovidcert/queue_notify-new-profile/terragrunt.hcl
@@ -1,0 +1,17 @@
+dependency "storage_account" {
+  config_path = "../account"
+}
+
+# Include all settings from the root terragrunt.hcl file
+include {
+  path = find_in_parent_folders()
+}
+
+terraform {
+  source = "git::git@github.com:pagopa/io-infrastructure-modules-new.git//azurerm_storage_queue?ref=v3.0.3"
+}
+
+inputs = {
+  name                  = "notify-new-profile"
+  storage_account_name  = dependency.storage_account.outputs.resource_name
+}

--- a/prod/westeurope/functions_app1/functions_app1_r3/function_app/terragrunt.hcl
+++ b/prod/westeurope/functions_app1/functions_app1_r3/function_app/terragrunt.hcl
@@ -52,6 +52,14 @@ dependency "storage_table_subscriptionsfeedbyday" {
   config_path = "../../../internal/api/storage/table_subscriptionsfeedbyday"
 }
 
+dependency "storage_account_apievents" {
+  config_path = "../../../internal/api/storage_apievents/account"
+}
+
+dependency "storage_account_apievents_queue_eucovidcert-profile-created" {
+  config_path = "../../../internal/api/storage_apievents/queue_eucovidcert-profile-created"
+}
+
 # operation
 dependency "storage_account_logs" {
   config_path = "../../../operations/storage_account_logs/account"
@@ -148,6 +156,9 @@ inputs = {
     NOTIFICATIONS_QUEUE_NAME                = dependency.notification_queue.outputs.name
     NOTIFICATIONS_STORAGE_CONNECTION_STRING = dependency.notification_storage_account.outputs.primary_connection_string
 
+    // Events configs
+    EventsQueueStorageConnection = dependency.storage_apievents.outputs.primary_connection_string
+
     SLOT_TASK_HUBNAME = "ProductionTaskHub"
 
     // Disable functions
@@ -182,9 +193,9 @@ inputs = {
     FF_ONLY_NATIONAL_SERVICES = "true"
     # Limit the number of local services
     FF_LOCAL_SERVICES_LIMIT = "0"
-    # Queue new users to notify to EUCOVIDCERT DGC
+    # eucovidcert configs
     FF_NEW_USERS_EUCOVIDCERT_ENABLED = "false"
-    EUCOVIDCERT_NOTIFY_QUEUE_NAME    = ""
+    EUCOVIDCERT_NOTIFY_QUEUE_NAME    = dependency.storage_account_apievents_queue_eucovidcert-profile-created.outputs.name
 
     WEBSITE_CONTENTSHARE = "io-p-fn3-app1-content"
 

--- a/prod/westeurope/functions_app1/functions_app1_r3/function_app/terragrunt.hcl
+++ b/prod/westeurope/functions_app1/functions_app1_r3/function_app/terragrunt.hcl
@@ -194,8 +194,8 @@ inputs = {
     # Limit the number of local services
     FF_LOCAL_SERVICES_LIMIT = "0"
     # eucovidcert configs
-    FF_NEW_USERS_EUCOVIDCERT_ENABLED = "false"
-    EUCOVIDCERT_NOTIFY_QUEUE_NAME    = dependency.storage_account_apievents_queue_eucovidcert-profile-created.outputs.name
+    FF_NEW_USERS_EUCOVIDCERT_ENABLED       = "false"
+    EUCOVIDCERT_PROFILE_CREATED_QUEUE_NAME = dependency.storage_account_apievents_queue_eucovidcert-profile-created.outputs.name
 
     WEBSITE_CONTENTSHARE = "io-p-fn3-app1-content"
 

--- a/prod/westeurope/functions_app1/functions_app1_r3/function_app/terragrunt.hcl
+++ b/prod/westeurope/functions_app1/functions_app1_r3/function_app/terragrunt.hcl
@@ -182,6 +182,9 @@ inputs = {
     FF_ONLY_NATIONAL_SERVICES = "true"
     # Limit the number of local services
     FF_LOCAL_SERVICES_LIMIT = "0"
+    # Queue new users to notify to EUCOVIDCERT DGC
+    FF_NEW_USERS_EUCOVIDCERT_ENABLED = "false"
+    EUCOVIDCERT_NOTIFY_QUEUE_NAME    = ""
 
     WEBSITE_CONTENTSHARE = "io-p-fn3-app1-content"
 

--- a/prod/westeurope/functions_app1/functions_app1_r3/function_app/terragrunt.hcl
+++ b/prod/westeurope/functions_app1/functions_app1_r3/function_app/terragrunt.hcl
@@ -157,7 +157,7 @@ inputs = {
     NOTIFICATIONS_STORAGE_CONNECTION_STRING = dependency.notification_storage_account.outputs.primary_connection_string
 
     // Events configs
-    EventsQueueStorageConnection = dependency.storage_apievents.outputs.primary_connection_string
+    EventsQueueStorageConnection = dependency.storage_account_apievents.outputs.primary_connection_string
 
     SLOT_TASK_HUBNAME = "ProductionTaskHub"
 

--- a/prod/westeurope/functions_app1/functions_app1_r3/function_app_slot_staging/terragrunt.hcl
+++ b/prod/westeurope/functions_app1/functions_app1_r3/function_app_slot_staging/terragrunt.hcl
@@ -158,6 +158,8 @@ inputs = {
     FF_ONLY_NATIONAL_SERVICES = "true"
     # Limit the number of local services
     FF_LOCAL_SERVICES_LIMIT = "0"
+    # Queue new users to notify to EUCOVIDCERT DGC
+    FF_NEW_USERS_EUCOVIDCERT_ENABLED = "false"
 
     # this app settings is required to solve the issue:
     # https://github.com/terraform-providers/terraform-provider-azurerm/issues/10499

--- a/prod/westeurope/functions_app1/functions_app1_r3/function_app_slot_staging/terragrunt.hcl
+++ b/prod/westeurope/functions_app1/functions_app1_r3/function_app_slot_staging/terragrunt.hcl
@@ -155,7 +155,7 @@ inputs = {
     NOTIFICATIONS_STORAGE_CONNECTION_STRING = dependency.notification_storage_account.outputs.primary_connection_string
 
     // Events configs
-    EventsQueueStorageConnection = dependency.storage_apievents.outputs.primary_connection_string
+    EventsQueueStorageConnection = dependency.storage_account_apievents.outputs.primary_connection_string
 
     SLOT_TASK_HUBNAME = "StagingTaskHub"
 

--- a/prod/westeurope/functions_app1/functions_app1_r3/function_app_slot_staging/terragrunt.hcl
+++ b/prod/westeurope/functions_app1/functions_app1_r3/function_app_slot_staging/terragrunt.hcl
@@ -170,8 +170,8 @@ inputs = {
     # Limit the number of local services
     FF_LOCAL_SERVICES_LIMIT = "0"
     # eucovidcert configs
-    FF_NEW_USERS_EUCOVIDCERT_ENABLED = "false"
-    EUCOVIDCERT_NOTIFY_QUEUE_NAME    = dependency.storage_account_apievents_queue_eucovidcert-profile-created.outputs.name
+    FF_NEW_USERS_EUCOVIDCERT_ENABLED       = "false"
+    EUCOVIDCERT_PROFILE_CREATED_QUEUE_NAME = dependency.storage_account_apievents_queue_eucovidcert-profile-created.outputs.name
 
     # this app settings is required to solve the issue:
     # https://github.com/terraform-providers/terraform-provider-azurerm/issues/10499

--- a/prod/westeurope/functions_app1/functions_app1_r3/function_app_slot_staging/terragrunt.hcl
+++ b/prod/westeurope/functions_app1/functions_app1_r3/function_app_slot_staging/terragrunt.hcl
@@ -40,6 +40,14 @@ dependency "notification_storage_account" {
   config_path = "../../../internal/api/storage_notifications/account"
 }
 
+dependency "storage_account_apievents" {
+  config_path = "../../../internal/api/storage_apievents/account"
+}
+
+dependency "storage_account_apievents_queue_eucovidcert-profile-created" {
+  config_path = "../../../internal/api/storage_apievents/queue_eucovidcert-profile-created"
+}
+
 # common
 
 dependency "storage_account_assets" {
@@ -146,6 +154,9 @@ inputs = {
     NOTIFICATIONS_QUEUE_NAME                = dependency.notification_queue.outputs.name
     NOTIFICATIONS_STORAGE_CONNECTION_STRING = dependency.notification_storage_account.outputs.primary_connection_string
 
+    // Events configs
+    EventsQueueStorageConnection = dependency.storage_apievents.outputs.primary_connection_string
+
     SLOT_TASK_HUBNAME = "StagingTaskHub"
 
     # Disabled functions on slot - trigger, queue and timer
@@ -158,8 +169,9 @@ inputs = {
     FF_ONLY_NATIONAL_SERVICES = "true"
     # Limit the number of local services
     FF_LOCAL_SERVICES_LIMIT = "0"
-    # Queue new users to notify to EUCOVIDCERT DGC
+    # eucovidcert configs
     FF_NEW_USERS_EUCOVIDCERT_ENABLED = "false"
+    EUCOVIDCERT_NOTIFY_QUEUE_NAME    = dependency.storage_account_apievents_queue_eucovidcert-profile-created.outputs.name
 
     # this app settings is required to solve the issue:
     # https://github.com/terraform-providers/terraform-provider-azurerm/issues/10499

--- a/prod/westeurope/internal/api/functions_app2_r3/function_app/terragrunt.hcl
+++ b/prod/westeurope/internal/api/functions_app2_r3/function_app/terragrunt.hcl
@@ -156,7 +156,7 @@ inputs = {
     NOTIFICATIONS_STORAGE_CONNECTION_STRING = dependency.notification_storage_account.outputs.primary_connection_string
 
     // Events configs
-    EventsQueueStorageConnection = dependency.storage_apievents.outputs.primary_connection_string
+    EventsQueueStorageConnection = dependency.storage_account_apievents.outputs.primary_connection_string
 
     SLOT_TASK_HUBNAME = "ProductionTaskHub"
 

--- a/prod/westeurope/internal/api/functions_app2_r3/function_app/terragrunt.hcl
+++ b/prod/westeurope/internal/api/functions_app2_r3/function_app/terragrunt.hcl
@@ -35,6 +35,14 @@ dependency "resource_group" {
   config_path = "../../../resource_group"
 }
 
+dependency "storage_account_apievents" {
+  config_path = "../../storage_apievents/account"
+}
+
+dependency "storage_account_apievents_queue_eucovidcert-profile-created" {
+  config_path = "../../storage_apievents/queue_eucovidcert-profile-created"
+}
+
 # Linux
 dependency "subnet_appbackend_l1" {
   config_path = "../../../../linux/appbackendl1/subnet"
@@ -147,6 +155,9 @@ inputs = {
     NOTIFICATIONS_QUEUE_NAME                = dependency.notification_queue.outputs.name
     NOTIFICATIONS_STORAGE_CONNECTION_STRING = dependency.notification_storage_account.outputs.primary_connection_string
 
+    // Events configs
+    EventsQueueStorageConnection = dependency.storage_apievents.outputs.primary_connection_string
+
     SLOT_TASK_HUBNAME = "ProductionTaskHub"
 
     // Disable functions
@@ -181,6 +192,9 @@ inputs = {
     FF_ONLY_NATIONAL_SERVICES = "true"
     # Limit the number of local services
     FF_LOCAL_SERVICES_LIMIT = "0"
+    # eucovidcert configs
+    FF_NEW_USERS_EUCOVIDCERT_ENABLED = "false"
+    EUCOVIDCERT_NOTIFY_QUEUE_NAME    = dependency.storage_account_apievents_queue_eucovidcert-profile-created.outputs.name
 
     WEBSITE_CONTENTSHARE = "io-p-fn3-app2-content"
   }

--- a/prod/westeurope/internal/api/functions_app2_r3/function_app/terragrunt.hcl
+++ b/prod/westeurope/internal/api/functions_app2_r3/function_app/terragrunt.hcl
@@ -193,8 +193,8 @@ inputs = {
     # Limit the number of local services
     FF_LOCAL_SERVICES_LIMIT = "0"
     # eucovidcert configs
-    FF_NEW_USERS_EUCOVIDCERT_ENABLED = "false"
-    EUCOVIDCERT_NOTIFY_QUEUE_NAME    = dependency.storage_account_apievents_queue_eucovidcert-profile-created.outputs.name
+    FF_NEW_USERS_EUCOVIDCERT_ENABLED       = "false"
+    EUCOVIDCERT_PROFILE_CREATED_QUEUE_NAME = dependency.storage_account_apievents_queue_eucovidcert-profile-created.outputs.name
 
     WEBSITE_CONTENTSHARE = "io-p-fn3-app2-content"
   }

--- a/prod/westeurope/internal/api/functions_app2_r3/function_app_slot_staging/terragrunt.hcl
+++ b/prod/westeurope/internal/api/functions_app2_r3/function_app_slot_staging/terragrunt.hcl
@@ -151,7 +151,7 @@ inputs = {
     NOTIFICATIONS_STORAGE_CONNECTION_STRING = dependency.notification_storage_account.outputs.primary_connection_string
 
     // Events configs
-    EventsQueueStorageConnection = dependency.storage_apievents.outputs.primary_connection_string
+    EventsQueueStorageConnection = dependency.storage_account_apievents.outputs.primary_connection_string
 
     SLOT_TASK_HUBNAME = "StagingTaskHub"
 

--- a/prod/westeurope/internal/api/functions_app2_r3/function_app_slot_staging/terragrunt.hcl
+++ b/prod/westeurope/internal/api/functions_app2_r3/function_app_slot_staging/terragrunt.hcl
@@ -39,6 +39,14 @@ dependency "resource_group" {
   config_path = "../../../resource_group"
 }
 
+dependency "storage_account_apievents" {
+  config_path = "../../storage_apievents/account"
+}
+
+dependency "storage_account_apievents_queue_eucovidcert-profile-created" {
+  config_path = "../../storage_apievents/queue_eucovidcert-profile-created"
+}
+
 # Linux
 dependency "subnet_appbackend_l1" {
   config_path = "../../../../linux/appbackendl1/subnet"
@@ -142,6 +150,9 @@ inputs = {
     NOTIFICATIONS_QUEUE_NAME                = dependency.notification_queue.outputs.name
     NOTIFICATIONS_STORAGE_CONNECTION_STRING = dependency.notification_storage_account.outputs.primary_connection_string
 
+    // Events configs
+    EventsQueueStorageConnection = dependency.storage_apievents.outputs.primary_connection_string
+
     SLOT_TASK_HUBNAME = "StagingTaskHub"
 
     # Disabled functions on slot - trigger, queue and timer
@@ -154,6 +165,9 @@ inputs = {
     FF_ONLY_NATIONAL_SERVICES = "true"
     # Limit the number of local services
     FF_LOCAL_SERVICES_LIMIT = "0"
+    # eucovidcert configs
+    FF_NEW_USERS_EUCOVIDCERT_ENABLED = "false"
+    EUCOVIDCERT_NOTIFY_QUEUE_NAME    = dependency.storage_account_apievents_queue_eucovidcert-profile-created.outputs.name
 
     # this app settings is required to solve the issue:
     # https://github.com/terraform-providers/terraform-provider-azurerm/issues/10499

--- a/prod/westeurope/internal/api/functions_app2_r3/function_app_slot_staging/terragrunt.hcl
+++ b/prod/westeurope/internal/api/functions_app2_r3/function_app_slot_staging/terragrunt.hcl
@@ -166,8 +166,8 @@ inputs = {
     # Limit the number of local services
     FF_LOCAL_SERVICES_LIMIT = "0"
     # eucovidcert configs
-    FF_NEW_USERS_EUCOVIDCERT_ENABLED = "false"
-    EUCOVIDCERT_NOTIFY_QUEUE_NAME    = dependency.storage_account_apievents_queue_eucovidcert-profile-created.outputs.name
+    FF_NEW_USERS_EUCOVIDCERT_ENABLED       = "false"
+    EUCOVIDCERT_PROFILE_CREATED_QUEUE_NAME = dependency.storage_account_apievents_queue_eucovidcert-profile-created.outputs.name
 
     # this app settings is required to solve the issue:
     # https://github.com/terraform-providers/terraform-provider-azurerm/issues/10499

--- a/prod/westeurope/internal/api/storage_apievents/account/terragrunt.hcl
+++ b/prod/westeurope/internal/api/storage_apievents/account/terragrunt.hcl
@@ -1,0 +1,24 @@
+# Internal
+dependency "resource_group" {
+  config_path = "../../../resource_group"
+}
+
+# Include all settings from the root terragrunt.hcl file
+include {
+  path = find_in_parent_folders()
+}
+
+terraform {
+  source = "git::git@github.com:pagopa/io-infrastructure-modules-new.git//azurerm_storage_account?ref=v3.0.3"
+}
+
+inputs = {
+  name                     = "apievents"
+  resource_group_name      = dependency.resource_group.outputs.resource_name
+  account_kind             = "StorageV2"
+  account_tier             = "Standard"
+  account_replication_type = "GRS"
+  access_tier              = "Hot"
+
+  enable_versioning = true
+}

--- a/prod/westeurope/internal/api/storage_apievents/queue_eucovidcert-profile-created/terragrunt.hcl
+++ b/prod/westeurope/internal/api/storage_apievents/queue_eucovidcert-profile-created/terragrunt.hcl
@@ -1,0 +1,17 @@
+dependency "storage_account" {
+  config_path = "../account"
+}
+
+# Include all settings from the root terragrunt.hcl file
+include {
+  path = find_in_parent_folders()
+}
+
+terraform {
+  source = "git::git@github.com:pagopa/io-infrastructure-modules-new.git//azurerm_storage_queue?ref=v3.0.3"
+}
+
+inputs = {
+  name                  = "eucovidcert-profile-created"
+  storage_account_name  = dependency.storage_account.outputs.resource_name
+}


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

### List of changes

1. add storage_apievents and queue_eucovidcert-profile-created
2. add config to fn-app
3. add config to fn-eucovidcert

### Motivation and context

Resources for eucovidcert notify flow

### Type of changes

- [x] Add new resources
- [x] Update configuration to existing resources
- [ ] Remove existing resources

### Does this introduce a change to production resources with possible user impact?

- [x] Yes, users may be impacted applying this change
- [ ] No

### Does this introduce an unwanted change on infrastructure? Check terraform plan execution result

- [x] Yes
- [ ] No

### Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->

---

### If PR is partially applied, why? (reserved to mantainers)

<!--- Describe the blocking cause -->
