### PR TITLE
add env variables for here geolocation APIs

### DIFF
--- a/prod/westeurope/linux/appbackendl1/app_service/terragrunt.hcl
+++ b/prod/westeurope/linux/appbackendl1/app_service/terragrunt.hcl
@@ -168,10 +168,16 @@ inputs = {
     BONUS_API_URL = "http://${dependency.functions_bonus.outputs.default_hostname}/api/v1"
     CGN_API_URL   = "http://${dependency.functions_cgn.outputs.default_hostname}/api/v1"
 
+    // THIRD PARTY APIS
+    HERE_AUTOCOMPLETE_API_URL = "https://autocomplete.search.hereapi.com"
+    HERE_GEOCODE_API_URL      = "https://geocode.search.hereapi.com"
+    HERE_LOOKUP_API_URL       = "https://lookup.search.hereapi.com"
+
     // EXPOSED API
     API_BASE_PATH       = "/api/v1"
     BONUS_API_BASE_PATH = "/api/v1"
     CGN_API_BASE_PATH   = "/api/v1"
+    GEO_API_BASE_PATH   = "/api/v1"
 
     // REDIS
     REDIS_URL      = dependency.redis.outputs.hostname
@@ -247,6 +253,9 @@ inputs = {
 
       // CGN BETA
       TEST_CGN_FISCAL_CODES = "appbackend-TEST-CGN-FISCAL-CODES"
+
+      // HERE APIS
+      HERE_API_KEY          = "appbackend-HERE-API-KEY"
     }
   }
 

--- a/prod/westeurope/linux/appbackendl1/app_service_slot_staging/terragrunt.hcl
+++ b/prod/westeurope/linux/appbackendl1/app_service_slot_staging/terragrunt.hcl
@@ -162,10 +162,16 @@ inputs = {
     BONUS_API_URL = "http://${dependency.functions_bonus.outputs.default_hostname}/api/v1"
     CGN_API_URL   = "http://${dependency.functions_cgn.outputs.default_hostname}/api/v1"
 
+    // THIRD PARTY APIS
+    HERE_AUTOCOMPLETE_API_URL = "https://autocomplete.search.hereapi.com"
+    HERE_GEOCODE_API_URL      = "https://geocode.search.hereapi.com"
+    HERE_LOOKUP_API_URL       = "https://lookup.search.hereapi.com"
+
     // EXPOSED API
     API_BASE_PATH       = "/api/v1"
     BONUS_API_BASE_PATH = "/api/v1"
     CGN_API_BASE_PATH   = "/api/v1"
+    GEO_API_BASE_PATH   = "/api/v1"
 
     // REDIS
     REDIS_URL      = dependency.redis.outputs.hostname
@@ -241,6 +247,9 @@ inputs = {
 
       // CGN BETA
       TEST_CGN_FISCAL_CODES             = "appbackend-TEST-CGN-FISCAL-CODES"
+
+      // HERE APIS
+      HERE_API_KEY          = "appbackend-HERE-API-KEY"
     }
   }
 

--- a/prod/westeurope/linux/appbackendl2/app_service/terragrunt.hcl
+++ b/prod/westeurope/linux/appbackendl2/app_service/terragrunt.hcl
@@ -168,10 +168,16 @@ inputs = {
     BONUS_API_URL = "http://${dependency.functions_bonus.outputs.default_hostname}/api/v1"
     CGN_API_URL   = "http://${dependency.functions_cgn.outputs.default_hostname}/api/v1"
 
+    // THIRD PARTY APIS
+    HERE_AUTOCOMPLETE_API_URL = "https://autocomplete.search.hereapi.com"
+    HERE_GEOCODE_API_URL      = "https://geocode.search.hereapi.com"
+    HERE_LOOKUP_API_URL       = "https://lookup.search.hereapi.com"
+
     // EXPOSED API
     API_BASE_PATH       = "/api/v1"
     BONUS_API_BASE_PATH = "/api/v1"
     CGN_API_BASE_PATH   = "/api/v1"
+    GEO_API_BASE_PATH   = "/api/v1"
 
     // REDIS
     REDIS_URL      = dependency.redis.outputs.hostname
@@ -247,6 +253,9 @@ inputs = {
 
       // CGN BETA
       TEST_CGN_FISCAL_CODES             = "appbackend-TEST-CGN-FISCAL-CODES"
+
+      // HERE APIS
+      HERE_API_KEY          = "appbackend-HERE-API-KEY"
     }
   }
 

--- a/prod/westeurope/linux/appbackendl2/app_service_slot_staging/terragrunt.hcl
+++ b/prod/westeurope/linux/appbackendl2/app_service_slot_staging/terragrunt.hcl
@@ -162,10 +162,16 @@ inputs = {
     BONUS_API_URL = "http://${dependency.functions_bonus.outputs.default_hostname}/api/v1"
     CGN_API_URL   = "http://${dependency.functions_cgn.outputs.default_hostname}/api/v1"
 
+    // THIRD PARTY APIS
+    HERE_AUTOCOMPLETE_API_URL = "https://autocomplete.search.hereapi.com"
+    HERE_GEOCODE_API_URL      = "https://geocode.search.hereapi.com"
+    HERE_LOOKUP_API_URL       = "https://lookup.search.hereapi.com"
+
     // EXPOSED API
     API_BASE_PATH       = "/api/v1"
     BONUS_API_BASE_PATH = "/api/v1"
     CGN_API_BASE_PATH   = "/api/v1"
+    GEO_API_BASE_PATH   = "/api/v1"
 
     // REDIS
     REDIS_URL      = dependency.redis.outputs.hostname
@@ -241,6 +247,9 @@ inputs = {
 
       // CGN BETA
       TEST_CGN_FISCAL_CODES             = "appbackend-TEST-CGN-FISCAL-CODES"
+
+      // HERE APIS
+      HERE_API_KEY          = "appbackend-HERE-API-KEY"
     }
   }
 

--- a/prod/westeurope/linux/appbackendli/app_service/terragrunt.hcl
+++ b/prod/westeurope/linux/appbackendli/app_service/terragrunt.hcl
@@ -169,10 +169,16 @@ inputs = {
     BONUS_API_URL = "http://${dependency.functions_bonus.outputs.default_hostname}/api/v1"
     CGN_API_URL   = "http://${dependency.functions_cgn.outputs.default_hostname}/api/v1"
 
+    // THIRD PARTY APIS
+    HERE_AUTOCOMPLETE_API_URL = "https://autocomplete.search.hereapi.com"
+    HERE_GEOCODE_API_URL      = "https://geocode.search.hereapi.com"
+    HERE_LOOKUP_API_URL       = "https://lookup.search.hereapi.com"
+
     // EXPOSED API
     API_BASE_PATH       = "/api/v1"
     BONUS_API_BASE_PATH = "/api/v1"
     CGN_API_BASE_PATH   = "/api/v1"
+    GEO_API_BASE_PATH   = "/api/v1"
 
     // REDIS
     REDIS_URL      = dependency.redis.outputs.hostname
@@ -248,6 +254,9 @@ inputs = {
 
       // CGN BETA
       TEST_CGN_FISCAL_CODES             = "appbackend-TEST-CGN-FISCAL-CODES"
+
+      // HERE APIS
+      HERE_API_KEY          = "appbackend-HERE-API-KEY"
     }
   }
 

--- a/prod/westeurope/linux/appbackendli/app_service_slot_staging/terragrunt.hcl
+++ b/prod/westeurope/linux/appbackendli/app_service_slot_staging/terragrunt.hcl
@@ -163,10 +163,16 @@ inputs = {
     BONUS_API_URL = "http://${dependency.functions_bonus.outputs.default_hostname}/api/v1"
     CGN_API_URL   = "http://${dependency.functions_cgn.outputs.default_hostname}/api/v1"
 
+    // THIRD PARTY APIS
+    HERE_AUTOCOMPLETE_API_URL = "https://autocomplete.search.hereapi.com"
+    HERE_GEOCODE_API_URL      = "https://geocode.search.hereapi.com"
+    HERE_LOOKUP_API_URL       = "https://lookup.search.hereapi.com"
+
     // EXPOSED API
     API_BASE_PATH       = "/api/v1"
     BONUS_API_BASE_PATH = "/api/v1"
     CGN_API_BASE_PATH   = "/api/v1"
+    GEO_API_BASE_PATH   = "/api/v1"
 
     // REDIS
     REDIS_URL      = dependency.redis.outputs.hostname
@@ -242,6 +248,9 @@ inputs = {
 
       // CGN BETA
       TEST_CGN_FISCAL_CODES             = "appbackend-TEST-CGN-FISCAL-CODES"
+
+      // HERE APIS
+      HERE_API_KEY          = "appbackend-HERE-API-KEY"
     }
   }
 


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

### List of changes

<!--- Describe your changes in detail -->
- Add env variables toio-backend in order to enable Here Apis
### Motivation and context

<!--- Why is this change required? What problem does it solve? -->
This changes are needed to add geolocation and autocomplete feature on CGN, while searching for operators around a specified position.
### Type of changes

- [ ] Add new resources
- [x] Update configuration to existing resources
- [ ] Remove existing resources

### Does this introduce a change to production resources with possible user impact?

- [ ] Yes, users may be impacted applying this change
- [x] No

### Does this introduce an unwanted change on infrastructure? Check terraform plan execution result

- [ ] Yes
- [ ] No

### Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->

---

### If PR is partially applied, why? (reserved to mantainers)

<!--- Describe the blocking cause -->
