### PR TITLE
Fix eucovidcert backend base path

### DIFF
--- a/prod/westeurope/linux/appbackendl1/app_service/terragrunt.hcl
+++ b/prod/westeurope/linux/appbackendl1/app_service/terragrunt.hcl
@@ -178,7 +178,7 @@ inputs = {
     API_BASE_PATH             = "/api/v1"
     BONUS_API_BASE_PATH       = "/api/v1"
     CGN_API_BASE_PATH         = "/api/v1"
-    EUCOVIDCERT_API_BASE_PATH = "/api/v1"
+    EUCOVIDCERT_API_BASE_PATH = "/api/v1/eucovidcert"
 
     // REDIS
     REDIS_URL      = dependency.redis.outputs.hostname

--- a/prod/westeurope/linux/appbackendl1/app_service_slot_staging/terragrunt.hcl
+++ b/prod/westeurope/linux/appbackendl1/app_service_slot_staging/terragrunt.hcl
@@ -172,7 +172,7 @@ inputs = {
     API_BASE_PATH             = "/api/v1"
     BONUS_API_BASE_PATH       = "/api/v1"
     CGN_API_BASE_PATH         = "/api/v1"
-    EUCOVIDCERT_API_BASE_PATH = "/api/v1"
+    EUCOVIDCERT_API_BASE_PATH = "/api/v1/eucovidcert"
 
     // REDIS
     REDIS_URL      = dependency.redis.outputs.hostname

--- a/prod/westeurope/linux/appbackendl1/app_service_slot_staging/terragrunt.hcl
+++ b/prod/westeurope/linux/appbackendl1/app_service_slot_staging/terragrunt.hcl
@@ -209,6 +209,7 @@ inputs = {
     // Feature flags
     FF_BONUS_ENABLED        = 1
     FF_CGN_ENABLED          = 1
+    FF_EUCOVIDCERT_ENABLED  = 1
     TEST_LOGIN_FISCAL_CODES = local.testusersvars.locals.test_users
 
     # No downtime on slots swap

--- a/prod/westeurope/linux/appbackendl2/app_service/terragrunt.hcl
+++ b/prod/westeurope/linux/appbackendl2/app_service/terragrunt.hcl
@@ -178,7 +178,7 @@ inputs = {
     API_BASE_PATH             = "/api/v1"
     BONUS_API_BASE_PATH       = "/api/v1"
     CGN_API_BASE_PATH         = "/api/v1"
-    EUCOVIDCERT_API_BASE_PATH = "/api/v1"
+    EUCOVIDCERT_API_BASE_PATH = "/api/v1/eucovidcert"
 
     // REDIS
     REDIS_URL      = dependency.redis.outputs.hostname

--- a/prod/westeurope/linux/appbackendl2/app_service_slot_staging/terragrunt.hcl
+++ b/prod/westeurope/linux/appbackendl2/app_service_slot_staging/terragrunt.hcl
@@ -172,7 +172,7 @@ inputs = {
     API_BASE_PATH             = "/api/v1"
     BONUS_API_BASE_PATH       = "/api/v1"
     CGN_API_BASE_PATH         = "/api/v1"
-    EUCOVIDCERT_API_BASE_PATH = "/api/v1"
+    EUCOVIDCERT_API_BASE_PATH = "/api/v1/eucovidcert"
 
     // REDIS
     REDIS_URL      = dependency.redis.outputs.hostname

--- a/prod/westeurope/linux/appbackendl2/app_service_slot_staging/terragrunt.hcl
+++ b/prod/westeurope/linux/appbackendl2/app_service_slot_staging/terragrunt.hcl
@@ -209,6 +209,7 @@ inputs = {
     // Feature flags
     FF_BONUS_ENABLED        = 1
     FF_CGN_ENABLED          = 1
+    FF_EUCOVIDCERT_ENABLED  = 1
     TEST_LOGIN_FISCAL_CODES = local.testusersvars.locals.test_users
 
     # No downtime on slots swap

--- a/prod/westeurope/linux/appbackendli/app_service/terragrunt.hcl
+++ b/prod/westeurope/linux/appbackendli/app_service/terragrunt.hcl
@@ -176,9 +176,9 @@ inputs = {
     EUCOVIDCERT_API_URL   = "http://${dependency.functions_eucovidcert.outputs.default_hostname}/api/v1"
 
     // EXPOSED API
-    API_BASE_PATH               = "/api/v1"
-    BONUS_API_BASE_PATH         = "/api/v1"
-    CGN_API_BASE_PATH           = "/api/v1"
+    API_BASE_PATH             = "/api/v1"
+    BONUS_API_BASE_PATH       = "/api/v1"
+    CGN_API_BASE_PATH         = "/api/v1"
     EUCOVIDCERT_API_BASE_PATH = "/api/v1/eucovidcert"
 
     // REDIS

--- a/prod/westeurope/linux/appbackendli/app_service/terragrunt.hcl
+++ b/prod/westeurope/linux/appbackendli/app_service/terragrunt.hcl
@@ -179,7 +179,7 @@ inputs = {
     API_BASE_PATH               = "/api/v1"
     BONUS_API_BASE_PATH         = "/api/v1"
     CGN_API_BASE_PATH           = "/api/v1"
-    EUCOVIDCERT_API_BASE_PATH   = "/api/v1"
+    EUCOVIDCERT_API_BASE_PATH = "/api/v1/eucovidcert"
 
     // REDIS
     REDIS_URL      = dependency.redis.outputs.hostname

--- a/prod/westeurope/linux/appbackendli/app_service_slot_staging/terragrunt.hcl
+++ b/prod/westeurope/linux/appbackendli/app_service_slot_staging/terragrunt.hcl
@@ -173,7 +173,7 @@ inputs = {
     API_BASE_PATH             = "/api/v1"
     BONUS_API_BASE_PATH       = "/api/v1"
     CGN_API_BASE_PATH         = "/api/v1"
-    EUCOVIDCERT_API_BASE_PATH = "/api/v1"
+    EUCOVIDCERT_API_BASE_PATH = "/api/v1/eucovidcert"
 
     // REDIS
     REDIS_URL      = dependency.redis.outputs.hostname


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

### List of changes

<!--- Describe your changes in detail -->
Fix eucovidcert backend base path to     `/api/v1/eucovidcert`

### Motivation and context

<!--- Why is this change required? What problem does it solve? -->
Bugfixing

### Type of changes

- [ ] Add new resources
- [x] Update configuration to existing resources
- [ ] Remove existing resources

### Does this introduce a change to production resources with possible user impact?

- [x] Yes, users may be impacted applying this change
- [ ] No

### Does this introduce an unwanted change on infrastructure? Check terraform plan execution result

- [ ] Yes
- [ ] No

### Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->

---

### If PR is partially applied, why? (reserved to mantainers)

<!--- Describe the blocking cause -->
