### PR TITLE
[#IPV-64] Disable queue listeners on `fn3-eucovidcert` staging slot

### DIFF
--- a/prod/westeurope/eucovidcert/functions_eucovidcert/function_app_slot_staging/terragrunt.hcl
+++ b/prod/westeurope/eucovidcert/functions_eucovidcert/function_app_slot_staging/terragrunt.hcl
@@ -132,6 +132,11 @@ inputs = {
 
     APPINSIGHTS_SAMPLING_PERCENTAGE = 5
 
+
+    // Disable listener functions
+    "AzureWebJobs.NotifyNewProfileToDGC.Disabled" = "1"
+    "AzureWebJobs.OnProfileCreatedEvent.Disabled" = "1"
+
     # this app settings is required to solve the issue:
     # https://github.com/terraform-providers/terraform-provider-azurerm/issues/10499
     WEBSITE_CONTENTSHARE = "staging-content"


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

### List of changes
* disabled `OnProfileCreatedEvent` and `NotifyNewProfileToDGC` on `fn3-eucovidcert` staging slot

<!--- Describe your changes in detail -->

### Motivation and context

<!--- Why is this change required? What problem does it solve? -->
So that staging slot does not consume messages from production queue

### Type of changes

- [ ] Add new resources
- [x] Update configuration to existing resources
- [ ] Remove existing resources

### Does this introduce a change to production resources with possible user impact?

- [ ] Yes, users may be impacted applying this change
- [x] No

### Does this introduce an unwanted change on infrastructure? Check terraform plan execution result

- [ ] Yes
- [x] No

### Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->

---

### If PR is partially applied, why? (reserved to mantainers)

<!--- Describe the blocking cause -->
