### PR TITLE
add load test users in notifications blacklist

### DIFF
--- a/prod/westeurope/notifications/functions_pushnotif/function_app/terragrunt.hcl
+++ b/prod/westeurope/notifications/functions_pushnotif/function_app/terragrunt.hcl
@@ -104,7 +104,7 @@ inputs = {
     FETCH_KEEPALIVE_FREE_SOCKET_TIMEOUT = "30000"
     FETCH_KEEPALIVE_TIMEOUT             = "60000"
 
-    FISCAL_CODE_NOTIFICATION_BLACKLIST = join(",", local.testusersvars.test_users_internal_load)
+    FISCAL_CODE_NOTIFICATION_BLACKLIST = join(",", local.testusersvars.locals.test_users_internal_load)
 
     NOTIFICATIONS_QUEUE_NAME                = dependency.storage_notifications_queue_push-notifications.outputs.name
     NOTIFICATIONS_STORAGE_CONNECTION_STRING = dependency.storage_notifications.outputs.primary_connection_string

--- a/prod/westeurope/notifications/functions_pushnotif/function_app/terragrunt.hcl
+++ b/prod/westeurope/notifications/functions_pushnotif/function_app/terragrunt.hcl
@@ -65,6 +65,7 @@ terraform {
 
 locals {
   commonvars                   = read_terragrunt_config(find_in_parent_folders("commonvars.hcl"))
+  testusersvars                = read_terragrunt_config(find_in_parent_folders("testusersvars.hcl"))
   app_insights_ips_west_europe = local.commonvars.locals.app_insights_ips_west_europe
 }
 
@@ -103,6 +104,7 @@ inputs = {
     FETCH_KEEPALIVE_FREE_SOCKET_TIMEOUT = "30000"
     FETCH_KEEPALIVE_TIMEOUT             = "60000"
 
+    TEST_LOGIN_FISCAL_CODES = test_users = join(",", local.testusersvars.test_users_internal_load)
 
     NOTIFICATIONS_QUEUE_NAME                = dependency.storage_notifications_queue_push-notifications.outputs.name
     NOTIFICATIONS_STORAGE_CONNECTION_STRING = dependency.storage_notifications.outputs.primary_connection_string

--- a/prod/westeurope/notifications/functions_pushnotif/function_app/terragrunt.hcl
+++ b/prod/westeurope/notifications/functions_pushnotif/function_app/terragrunt.hcl
@@ -104,7 +104,7 @@ inputs = {
     FETCH_KEEPALIVE_FREE_SOCKET_TIMEOUT = "30000"
     FETCH_KEEPALIVE_TIMEOUT             = "60000"
 
-    TEST_LOGIN_FISCAL_CODES = test_users = join(",", local.testusersvars.test_users_internal_load)
+    FISCAL_CODE_NOTIFICATION_BLACKLIST = join(",", local.testusersvars.test_users_internal_load)
 
     NOTIFICATIONS_QUEUE_NAME                = dependency.storage_notifications_queue_push-notifications.outputs.name
     NOTIFICATIONS_STORAGE_CONNECTION_STRING = dependency.storage_notifications.outputs.primary_connection_string
@@ -138,12 +138,12 @@ inputs = {
     # Variable used during transition to new NH management
 
     # Possible values : "none" | "all" | "beta" | "canary"
-    NH_PARTITION_FEATURE_FLAG             = "all"
-    BETA_USERS_STORAGE_CONNECTION_STRING  = dependency.storage_beta_test_users.outputs.primary_connection_string
-    BETA_USERS_TABLE_NAME                 = dependency.storage_beta_test_users_table_notificationhub.outputs.name
-    
+    NH_PARTITION_FEATURE_FLAG            = "all"
+    BETA_USERS_STORAGE_CONNECTION_STRING = dependency.storage_beta_test_users.outputs.primary_connection_string
+    BETA_USERS_TABLE_NAME                = dependency.storage_beta_test_users_table_notificationhub.outputs.name
+
     # Takes ~6,25% of users
-    CANARY_USERS_REGEX                    = "^([(0-9)|(a-f)|(A-F)]{63}0)$"
+    CANARY_USERS_REGEX = "^([(0-9)|(a-f)|(A-F)]{63}0)$"
     # ------------------------------------------------------------------------------
 
     // Disable functions

--- a/prod/westeurope/notifications/functions_pushnotif/function_app_slot_staging/terragrunt.hcl
+++ b/prod/westeurope/notifications/functions_pushnotif/function_app_slot_staging/terragrunt.hcl
@@ -109,7 +109,7 @@ inputs = {
 
     SLOT_TASK_HUBNAME = "StagingTaskHub"
 
-    FISCAL_CODE_NOTIFICATION_BLACKLIST = join(",", local.testusersvars.test_users_internal_load)
+    FISCAL_CODE_NOTIFICATION_BLACKLIST = join(",", local.testusersvars.locals.test_users_internal_load)
 
     // activity default retry attempts
     RETRY_ATTEMPT_NUMBER = 10

--- a/prod/westeurope/notifications/functions_pushnotif/function_app_slot_staging/terragrunt.hcl
+++ b/prod/westeurope/notifications/functions_pushnotif/function_app_slot_staging/terragrunt.hcl
@@ -67,6 +67,10 @@ include {
   path = find_in_parent_folders()
 }
 
+locals {
+  testusersvars = read_terragrunt_config(find_in_parent_folders("testusersvars.hcl"))
+}
+
 terraform {
   source = "git::git@github.com:pagopa/io-infrastructure-modules-new.git//azurerm_function_app_slot?ref=v3.0.3"
 }
@@ -134,12 +138,12 @@ inputs = {
     # Variable used during transition to new NH management
 
     # Possible values : "none" | "all" | "beta" | "canary"
-    NH_PARTITION_FEATURE_FLAG             = "all"
-    BETA_USERS_STORAGE_CONNECTION_STRING  = dependency.storage_beta_test_users.outputs.primary_connection_string
-    BETA_USERS_TABLE_NAME                 = dependency.storage_beta_test_users_table_notificationhub.outputs.name
-    
+    NH_PARTITION_FEATURE_FLAG            = "all"
+    BETA_USERS_STORAGE_CONNECTION_STRING = dependency.storage_beta_test_users.outputs.primary_connection_string
+    BETA_USERS_TABLE_NAME                = dependency.storage_beta_test_users_table_notificationhub.outputs.name
+
     # Takes ~6,25% of users
-    CANARY_USERS_REGEX                    = "^([(0-9)|(a-f)|(A-F)]{63}0)$"
+    CANARY_USERS_REGEX = "^([(0-9)|(a-f)|(A-F)]{63}0)$"
     # ------------------------------------------------------------------------------
 
     // Disable functions
@@ -158,7 +162,7 @@ inputs = {
       NH2_ENDPOINT      = "common-partition-2-AZURE-NH-ENDPOINT"
       NH3_ENDPOINT      = "common-partition-3-AZURE-NH-ENDPOINT"
       NH4_ENDPOINT      = "common-partition-4-AZURE-NH-ENDPOINT"
-    }     
+    }
   }
 
   allowed_subnets = [
@@ -168,6 +172,6 @@ inputs = {
 
   allowed_ips = []
 
-  subnet_id = dependency.subnet.outputs.id
+  subnet_id       = dependency.subnet.outputs.id
   function_app_id = dependency.function_app.outputs.id
 }

--- a/prod/westeurope/notifications/functions_pushnotif/function_app_slot_staging/terragrunt.hcl
+++ b/prod/westeurope/notifications/functions_pushnotif/function_app_slot_staging/terragrunt.hcl
@@ -105,6 +105,8 @@ inputs = {
 
     SLOT_TASK_HUBNAME = "StagingTaskHub"
 
+    FISCAL_CODE_NOTIFICATION_BLACKLIST = join(",", local.testusersvars.test_users_internal_load)
+
     // activity default retry attempts
     RETRY_ATTEMPT_NUMBER = 10
 

--- a/prod/westeurope/notifications/sandbox/storage_notifications/queue_push-notifications/terragrunt.hcl
+++ b/prod/westeurope/notifications/sandbox/storage_notifications/queue_push-notifications/terragrunt.hcl
@@ -12,6 +12,6 @@ terraform {
 }
 
 inputs = {
-  name                  = "push-notifications-sandbox"
-  storage_account_name  = dependency.storage_account.outputs.resource_name
+  name                 = "push-notifications-sandbox"
+  storage_account_name = dependency.storage_account.outputs.resource_name
 }


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

### List of changes

<!--- Describe your changes in detail -->
* add `TEST_LOGIN_FISCAL_CODES` env var to `fn3-pushnotif`

### Motivation and context

<!--- Why is this change required? What problem does it solve? -->
We want to blacklist load test user to not overuse public notification services

### Type of changes

- [ ] Add new resources
- [x] Update configuration to existing resources
- [ ] Remove existing resources

### Does this introduce a change to production resources with possible user impact?

- [ ] Yes, users may be impacted applying this change
- [x] No

### Does this introduce an unwanted change on infrastructure? Check terraform plan execution result

- [ ] Yes
- [x] No

### Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->

---

### If PR is partially applied, why? (reserved to mantainers)

<!--- Describe the blocking cause -->
