### PR TITLE
[#IP-234] Disable message content for WEBHOOK channel

### DIFF
--- a/prod/westeurope/internal/api/functions_services_r3/function_app/terragrunt.hcl
+++ b/prod/westeurope/internal/api/functions_services_r3/function_app/terragrunt.hcl
@@ -115,6 +115,9 @@ inputs = {
     IO_FUNCTIONS_ADMIN_BASE_URL       = "http://api-internal.io.italia.it"
     DEFAULT_SUBSCRIPTION_PRODUCT_NAME = "io-services-api"
 
+    // setting to true all the webhook message content will be disabled
+    FF_DISABLE_WEBHOOK_MESSAGE_CONTENT = "true"
+
     # this app settings is required to solve the issue:
     # https://github.com/terraform-providers/terraform-provider-azurerm/issues/10499
     WEBSITE_CONTENTSHARE = "io-p-fn3-services-content"

--- a/prod/westeurope/internal/api/functions_services_r3/function_app_slot_staging/terragrunt.hcl
+++ b/prod/westeurope/internal/api/functions_services_r3/function_app_slot_staging/terragrunt.hcl
@@ -111,6 +111,9 @@ inputs = {
     IO_FUNCTIONS_ADMIN_BASE_URL       = "http://api-internal.io.italia.it"
     DEFAULT_SUBSCRIPTION_PRODUCT_NAME = "io-services-api"
 
+    // setting to true all the webhook message content will be disabled
+    FF_DISABLE_WEBHOOK_MESSAGE_CONTENT = "true"
+
     # this app settings is required to solve the issue:
     # https://github.com/terraform-providers/terraform-provider-azurerm/issues/10499
     WEBSITE_CONTENTSHARE = "staging-content"

--- a/prod/westeurope/services/functions_services01_r3/function_app/terragrunt.hcl
+++ b/prod/westeurope/services/functions_services01_r3/function_app/terragrunt.hcl
@@ -116,6 +116,9 @@ inputs = {
     IO_FUNCTIONS_ADMIN_BASE_URL       = "http://api-internal.io.italia.it"
     DEFAULT_SUBSCRIPTION_PRODUCT_NAME = "io-services-api"
 
+    // setting to true all the webhook message content will be disabled
+    FF_DISABLE_WEBHOOK_MESSAGE_CONTENT = "true"
+
     # this app settings is required to solve the issue:
     # https://github.com/terraform-providers/terraform-provider-azurerm/issues/10499
     WEBSITE_CONTENTSHARE = "io-p-fn3-services01-content"

--- a/prod/westeurope/services/functions_services01_r3/function_app_slot_staging/terragrunt.hcl
+++ b/prod/westeurope/services/functions_services01_r3/function_app_slot_staging/terragrunt.hcl
@@ -112,6 +112,9 @@ inputs = {
     IO_FUNCTIONS_ADMIN_BASE_URL       = "http://api-internal.io.italia.it"
     DEFAULT_SUBSCRIPTION_PRODUCT_NAME = "io-services-api"
 
+    // setting to true all the webhook message content will be disabled
+    FF_DISABLE_WEBHOOK_MESSAGE_CONTENT = "true"
+
     # this app settings is required to solve the issue:
     # https://github.com/terraform-providers/terraform-provider-azurerm/issues/10499
     WEBSITE_CONTENTSHARE = "staging-content"


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

### List of changes

- add `FF_DISABLE_WEBHOOK_MESSAGE_CONTENT = "true"`

### Motivation and context

https://github.com/pagopa/io-functions-services/pull/131

### Type of changes

- [ ] Add new resources
- [x] Update configuration to existing resources
- [ ] Remove existing resources

### Does this introduce a change to production resources with possible user impact?

- [ ] Yes, users may be impacted applying this change
- [x] No

### Does this introduce an unwanted change on infrastructure? Check terraform plan execution result

- [ ] Yes
- [x] No

### Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->

---

### If PR is partially applied, why? (reserved to mantainers)

<!--- Describe the blocking cause -->
