### PR TITLE
[#ISV-29] Enable Mit Voucher Jwt Token

### DIFF
--- a/prod/westeurope/linux/appbackendl1/app_service/terragrunt.hcl
+++ b/prod/westeurope/linux/appbackendl1/app_service/terragrunt.hcl
@@ -225,7 +225,7 @@ inputs = {
     FF_BONUS_ENABLED        = 1
     FF_CGN_ENABLED          = 1
     FF_EUCOVIDCERT_ENABLED  = 1
-    FF_MIT_VOUCHER_ENABLED  = 0
+    FF_MIT_VOUCHER_ENABLED  = 1
     TEST_LOGIN_FISCAL_CODES = local.testusersvars.locals.test_users
 
     # No downtime on slots swap

--- a/prod/westeurope/linux/appbackendl1/app_service/terragrunt.hcl
+++ b/prod/westeurope/linux/appbackendl1/app_service/terragrunt.hcl
@@ -183,6 +183,7 @@ inputs = {
     BONUS_API_BASE_PATH       = "/api/v1"
     CGN_API_BASE_PATH         = "/api/v1"
     EUCOVIDCERT_API_BASE_PATH = "/api/v1/eucovidcert"
+    MIT_VOUCHER_API_BASE_PATH = "/api/v1/mitvoucher/auth"
 
     // REDIS
     REDIS_URL      = dependency.redis.outputs.hostname
@@ -203,6 +204,10 @@ inputs = {
     // MYPORTAL
     MYPORTAL_BASE_PATH = "/myportal/api/v1"
 
+    // MIT_VOUCHER JWT
+    JWT_MIT_VOUCHER_TOKEN_ISSUER=app-backend.io.italia.it
+    JWT_MIT_VOUCHER_TOKEN_EXPIRATION=1200
+
     // BPD
     BPD_BASE_PATH = "/bpd/api/v1"
 
@@ -220,6 +225,7 @@ inputs = {
     FF_BONUS_ENABLED        = 1
     FF_CGN_ENABLED          = 1
     FF_EUCOVIDCERT_ENABLED  = 1
+    FF_MIT_VOUCHER_ENABLED  = 0
     TEST_LOGIN_FISCAL_CODES = local.testusersvars.locals.test_users
 
     # No downtime on slots swap
@@ -260,6 +266,10 @@ inputs = {
 
       // CGN BETA
       TEST_CGN_FISCAL_CODES = "appbackend-TEST-CGN-FISCAL-CODES"
+
+      // MIT_VOUCHER JWT
+      JWT_MIT_VOUCHER_TOKEN_PRIVATE_ES_KEY  = "appbackend-mitvoucher-JWT-PRIVATE-ES-KEY"
+      JWT_MIT_VOUCHER_TOKEN_AUDIENCE        = "appbackend-mitvoucher-JWT-AUDIENCE"
     }
   }
 

--- a/prod/westeurope/linux/appbackendl1/app_service/terragrunt.hcl
+++ b/prod/westeurope/linux/appbackendl1/app_service/terragrunt.hcl
@@ -205,7 +205,7 @@ inputs = {
     MYPORTAL_BASE_PATH = "/myportal/api/v1"
 
     // MIT_VOUCHER JWT
-    JWT_MIT_VOUCHER_TOKEN_ISSUER=app-backend.io.italia.it
+    JWT_MIT_VOUCHER_TOKEN_ISSUER="app-backend.io.italia.it"
     JWT_MIT_VOUCHER_TOKEN_EXPIRATION=1200
 
     // BPD

--- a/prod/westeurope/linux/appbackendl1/app_service_slot_staging/terragrunt.hcl
+++ b/prod/westeurope/linux/appbackendl1/app_service_slot_staging/terragrunt.hcl
@@ -177,6 +177,7 @@ inputs = {
     BONUS_API_BASE_PATH       = "/api/v1"
     CGN_API_BASE_PATH         = "/api/v1"
     EUCOVIDCERT_API_BASE_PATH = "/api/v1/eucovidcert"
+    MIT_VOUCHER_API_BASE_PATH = "/api/v1/mitvoucher/auth"
 
     // REDIS
     REDIS_URL      = dependency.redis.outputs.hostname
@@ -197,6 +198,10 @@ inputs = {
     // MYPORTAL
     MYPORTAL_BASE_PATH = "/myportal/api/v1"
 
+    // MIT_VOUCHER JWT
+    JWT_MIT_VOUCHER_TOKEN_ISSUER=app-backend.io.italia.it
+    JWT_MIT_VOUCHER_TOKEN_EXPIRATION=1200
+
     // BPD
     BPD_BASE_PATH = "/bpd/api/v1"
 
@@ -214,6 +219,7 @@ inputs = {
     FF_BONUS_ENABLED        = 1
     FF_CGN_ENABLED          = 1
     FF_EUCOVIDCERT_ENABLED  = 1
+    FF_MIT_VOUCHER_ENABLED  = 0
     TEST_LOGIN_FISCAL_CODES = local.testusersvars.locals.test_users
 
     # No downtime on slots swap
@@ -254,6 +260,10 @@ inputs = {
 
       // CGN BETA
       TEST_CGN_FISCAL_CODES             = "appbackend-TEST-CGN-FISCAL-CODES"
+
+      // MIT_VOUCHER JWT
+      JWT_MIT_VOUCHER_TOKEN_PRIVATE_ES_KEY  = "appbackend-mitvoucher-JWT-PRIVATE-ES-KEY"
+      JWT_MIT_VOUCHER_TOKEN_AUDIENCE        = "appbackend-mitvoucher-JWT-AUDIENCE"
     }
   }
 

--- a/prod/westeurope/linux/appbackendl1/app_service_slot_staging/terragrunt.hcl
+++ b/prod/westeurope/linux/appbackendl1/app_service_slot_staging/terragrunt.hcl
@@ -219,7 +219,7 @@ inputs = {
     FF_BONUS_ENABLED        = 1
     FF_CGN_ENABLED          = 1
     FF_EUCOVIDCERT_ENABLED  = 1
-    FF_MIT_VOUCHER_ENABLED  = 0
+    FF_MIT_VOUCHER_ENABLED  = 1
     TEST_LOGIN_FISCAL_CODES = local.testusersvars.locals.test_users
 
     # No downtime on slots swap

--- a/prod/westeurope/linux/appbackendl1/app_service_slot_staging/terragrunt.hcl
+++ b/prod/westeurope/linux/appbackendl1/app_service_slot_staging/terragrunt.hcl
@@ -199,7 +199,7 @@ inputs = {
     MYPORTAL_BASE_PATH = "/myportal/api/v1"
 
     // MIT_VOUCHER JWT
-    JWT_MIT_VOUCHER_TOKEN_ISSUER=app-backend.io.italia.it
+    JWT_MIT_VOUCHER_TOKEN_ISSUER="app-backend.io.italia.it"
     JWT_MIT_VOUCHER_TOKEN_EXPIRATION=1200
 
     // BPD

--- a/prod/westeurope/linux/appbackendl2/app_service/terragrunt.hcl
+++ b/prod/westeurope/linux/appbackendl2/app_service/terragrunt.hcl
@@ -225,7 +225,7 @@ inputs = {
     FF_BONUS_ENABLED        = 1
     FF_CGN_ENABLED          = 1
     FF_EUCOVIDCERT_ENABLED  = 1
-    FF_MIT_VOUCHER_ENABLED  = 0
+    FF_MIT_VOUCHER_ENABLED  = 1
     TEST_LOGIN_FISCAL_CODES = local.testusersvars.locals.test_users
 
     # No downtime on slots swap

--- a/prod/westeurope/linux/appbackendl2/app_service/terragrunt.hcl
+++ b/prod/westeurope/linux/appbackendl2/app_service/terragrunt.hcl
@@ -183,6 +183,7 @@ inputs = {
     BONUS_API_BASE_PATH       = "/api/v1"
     CGN_API_BASE_PATH         = "/api/v1"
     EUCOVIDCERT_API_BASE_PATH = "/api/v1/eucovidcert"
+    MIT_VOUCHER_API_BASE_PATH = "/api/v1/mitvoucher/auth"
 
     // REDIS
     REDIS_URL      = dependency.redis.outputs.hostname
@@ -203,6 +204,10 @@ inputs = {
     // MYPORTAL
     MYPORTAL_BASE_PATH = "/myportal/api/v1"
 
+    // MIT_VOUCHER JWT
+    JWT_MIT_VOUCHER_TOKEN_ISSUER=app-backend.io.italia.it
+    JWT_MIT_VOUCHER_TOKEN_EXPIRATION=1200
+
     // BPD
     BPD_BASE_PATH = "/bpd/api/v1"
 
@@ -220,6 +225,7 @@ inputs = {
     FF_BONUS_ENABLED        = 1
     FF_CGN_ENABLED          = 1
     FF_EUCOVIDCERT_ENABLED  = 1
+    FF_MIT_VOUCHER_ENABLED  = 0
     TEST_LOGIN_FISCAL_CODES = local.testusersvars.locals.test_users
 
     # No downtime on slots swap
@@ -260,6 +266,10 @@ inputs = {
 
       // CGN BETA
       TEST_CGN_FISCAL_CODES             = "appbackend-TEST-CGN-FISCAL-CODES"
+
+      // MIT_VOUCHER JWT
+      JWT_MIT_VOUCHER_TOKEN_PRIVATE_ES_KEY  = "appbackend-mitvoucher-JWT-PRIVATE-ES-KEY"
+      JWT_MIT_VOUCHER_TOKEN_AUDIENCE        = "appbackend-mitvoucher-JWT-AUDIENCE"
     }
   }
 

--- a/prod/westeurope/linux/appbackendl2/app_service/terragrunt.hcl
+++ b/prod/westeurope/linux/appbackendl2/app_service/terragrunt.hcl
@@ -205,7 +205,7 @@ inputs = {
     MYPORTAL_BASE_PATH = "/myportal/api/v1"
 
     // MIT_VOUCHER JWT
-    JWT_MIT_VOUCHER_TOKEN_ISSUER=app-backend.io.italia.it
+    JWT_MIT_VOUCHER_TOKEN_ISSUER="app-backend.io.italia.it"
     JWT_MIT_VOUCHER_TOKEN_EXPIRATION=1200
 
     // BPD

--- a/prod/westeurope/linux/appbackendl2/app_service_slot_staging/terragrunt.hcl
+++ b/prod/westeurope/linux/appbackendl2/app_service_slot_staging/terragrunt.hcl
@@ -177,6 +177,7 @@ inputs = {
     BONUS_API_BASE_PATH       = "/api/v1"
     CGN_API_BASE_PATH         = "/api/v1"
     EUCOVIDCERT_API_BASE_PATH = "/api/v1/eucovidcert"
+    MIT_VOUCHER_API_BASE_PATH = "/api/v1/mitvoucher/auth"
 
     // REDIS
     REDIS_URL      = dependency.redis.outputs.hostname
@@ -197,6 +198,10 @@ inputs = {
     // MYPORTAL
     MYPORTAL_BASE_PATH = "/myportal/api/v1"
 
+    // MIT_VOUCHER JWT
+    JWT_MIT_VOUCHER_TOKEN_ISSUER=app-backend.io.italia.it
+    JWT_MIT_VOUCHER_TOKEN_EXPIRATION=1200
+
     // BPD
     BPD_BASE_PATH = "/bpd/api/v1"
 
@@ -214,6 +219,7 @@ inputs = {
     FF_BONUS_ENABLED        = 1
     FF_CGN_ENABLED          = 1
     FF_EUCOVIDCERT_ENABLED  = 1
+    FF_MIT_VOUCHER_ENABLED  = 0
     TEST_LOGIN_FISCAL_CODES = local.testusersvars.locals.test_users
 
     # No downtime on slots swap
@@ -254,6 +260,10 @@ inputs = {
 
       // CGN BETA
       TEST_CGN_FISCAL_CODES             = "appbackend-TEST-CGN-FISCAL-CODES"
+  
+      // MIT_VOUCHER JWT
+      JWT_MIT_VOUCHER_TOKEN_PRIVATE_ES_KEY  = "appbackend-mitvoucher-JWT-PRIVATE-ES-KEY"
+      JWT_MIT_VOUCHER_TOKEN_AUDIENCE        = "appbackend-mitvoucher-JWT-AUDIENCE"
     }
   }
 

--- a/prod/westeurope/linux/appbackendl2/app_service_slot_staging/terragrunt.hcl
+++ b/prod/westeurope/linux/appbackendl2/app_service_slot_staging/terragrunt.hcl
@@ -219,7 +219,7 @@ inputs = {
     FF_BONUS_ENABLED        = 1
     FF_CGN_ENABLED          = 1
     FF_EUCOVIDCERT_ENABLED  = 1
-    FF_MIT_VOUCHER_ENABLED  = 0
+    FF_MIT_VOUCHER_ENABLED  = 1
     TEST_LOGIN_FISCAL_CODES = local.testusersvars.locals.test_users
 
     # No downtime on slots swap

--- a/prod/westeurope/linux/appbackendl2/app_service_slot_staging/terragrunt.hcl
+++ b/prod/westeurope/linux/appbackendl2/app_service_slot_staging/terragrunt.hcl
@@ -199,7 +199,7 @@ inputs = {
     MYPORTAL_BASE_PATH = "/myportal/api/v1"
 
     // MIT_VOUCHER JWT
-    JWT_MIT_VOUCHER_TOKEN_ISSUER=app-backend.io.italia.it
+    JWT_MIT_VOUCHER_TOKEN_ISSUER="app-backend.io.italia.it"
     JWT_MIT_VOUCHER_TOKEN_EXPIRATION=1200
 
     // BPD

--- a/prod/westeurope/linux/appbackendli/app_service/terragrunt.hcl
+++ b/prod/westeurope/linux/appbackendli/app_service/terragrunt.hcl
@@ -226,7 +226,7 @@ inputs = {
     FF_BONUS_ENABLED        = 1
     FF_CGN_ENABLED          = 1
     FF_EUCOVIDCERT_ENABLED  = 1
-    FF_MIT_VOUCHER_ENABLED  = 0
+    FF_MIT_VOUCHER_ENABLED  = 1
     TEST_LOGIN_FISCAL_CODES = local.testusersvars.locals.test_users
 
     # No downtime on slots swap

--- a/prod/westeurope/linux/appbackendli/app_service/terragrunt.hcl
+++ b/prod/westeurope/linux/appbackendli/app_service/terragrunt.hcl
@@ -206,7 +206,7 @@ inputs = {
     MYPORTAL_BASE_PATH = "/myportal/api/v1"
 
     // MIT_VOUCHER JWT
-    JWT_MIT_VOUCHER_TOKEN_ISSUER=app-backend.io.italia.it
+    JWT_MIT_VOUCHER_TOKEN_ISSUER="app-backend.io.italia.it"
     JWT_MIT_VOUCHER_TOKEN_EXPIRATION=1200
 
     // BPD

--- a/prod/westeurope/linux/appbackendli/app_service/terragrunt.hcl
+++ b/prod/westeurope/linux/appbackendli/app_service/terragrunt.hcl
@@ -184,6 +184,7 @@ inputs = {
     BONUS_API_BASE_PATH       = "/api/v1"
     CGN_API_BASE_PATH         = "/api/v1"
     EUCOVIDCERT_API_BASE_PATH = "/api/v1/eucovidcert"
+    MIT_VOUCHER_API_BASE_PATH = "/api/v1/mitvoucher/auth"
 
     // REDIS
     REDIS_URL      = dependency.redis.outputs.hostname
@@ -204,6 +205,10 @@ inputs = {
     // MYPORTAL
     MYPORTAL_BASE_PATH = "/myportal/api/v1"
 
+    // MIT_VOUCHER JWT
+    JWT_MIT_VOUCHER_TOKEN_ISSUER=app-backend.io.italia.it
+    JWT_MIT_VOUCHER_TOKEN_EXPIRATION=1200
+
     // BPD
     BPD_BASE_PATH = "/bpd/api/v1"
 
@@ -221,6 +226,7 @@ inputs = {
     FF_BONUS_ENABLED        = 1
     FF_CGN_ENABLED          = 1
     FF_EUCOVIDCERT_ENABLED  = 1
+    FF_MIT_VOUCHER_ENABLED  = 0
     TEST_LOGIN_FISCAL_CODES = local.testusersvars.locals.test_users
 
     # No downtime on slots swap
@@ -262,7 +268,9 @@ inputs = {
       // CGN BETA
       TEST_CGN_FISCAL_CODES             = "appbackend-TEST-CGN-FISCAL-CODES"
 
-
+      // MIT_VOUCHER JWT
+      JWT_MIT_VOUCHER_TOKEN_PRIVATE_ES_KEY  = "appbackend-mitvoucher-JWT-PRIVATE-ES-KEY"
+      JWT_MIT_VOUCHER_TOKEN_AUDIENCE        = "appbackend-mitvoucher-JWT-AUDIENCE"
     }
   }
 

--- a/prod/westeurope/linux/appbackendli/app_service_slot_staging/terragrunt.hcl
+++ b/prod/westeurope/linux/appbackendli/app_service_slot_staging/terragrunt.hcl
@@ -178,6 +178,7 @@ inputs = {
     BONUS_API_BASE_PATH       = "/api/v1"
     CGN_API_BASE_PATH         = "/api/v1"
     EUCOVIDCERT_API_BASE_PATH = "/api/v1/eucovidcert"
+    MIT_VOUCHER_API_BASE_PATH = "/api/v1/mitvoucher/auth"
 
     // REDIS
     REDIS_URL      = dependency.redis.outputs.hostname
@@ -198,6 +199,10 @@ inputs = {
     // MYPORTAL
     MYPORTAL_BASE_PATH = "/myportal/api/v1"
 
+    // MIT_VOUCHER JWT
+    JWT_MIT_VOUCHER_TOKEN_ISSUER=app-backend.io.italia.it
+    JWT_MIT_VOUCHER_TOKEN_EXPIRATION=1200
+
     // BPD
     BPD_BASE_PATH = "/bpd/api/v1"
 
@@ -215,6 +220,7 @@ inputs = {
     FF_BONUS_ENABLED        = 1
     FF_CGN_ENABLED          = 1
     FF_EUCOVIDCERT_ENABLED  = 1
+    FF_MIT_VOUCHER_ENABLED  = 0
     TEST_LOGIN_FISCAL_CODES = local.testusersvars.locals.test_users
 
     # No downtime on slots swap
@@ -255,6 +261,10 @@ inputs = {
 
       // CGN BETA
       TEST_CGN_FISCAL_CODES             = "appbackend-TEST-CGN-FISCAL-CODES"
+
+      // MIT_VOUCHER JWT
+      JWT_MIT_VOUCHER_TOKEN_PRIVATE_ES_KEY  = "appbackend-mitvoucher-JWT-PRIVATE-ES-KEY"
+      JWT_MIT_VOUCHER_TOKEN_AUDIENCE        = "appbackend-mitvoucher-JWT-AUDIENCE"
     }
   }
 

--- a/prod/westeurope/linux/appbackendli/app_service_slot_staging/terragrunt.hcl
+++ b/prod/westeurope/linux/appbackendli/app_service_slot_staging/terragrunt.hcl
@@ -220,7 +220,7 @@ inputs = {
     FF_BONUS_ENABLED        = 1
     FF_CGN_ENABLED          = 1
     FF_EUCOVIDCERT_ENABLED  = 1
-    FF_MIT_VOUCHER_ENABLED  = 0
+    FF_MIT_VOUCHER_ENABLED  = 1
     TEST_LOGIN_FISCAL_CODES = local.testusersvars.locals.test_users
 
     # No downtime on slots swap

--- a/prod/westeurope/linux/appbackendli/app_service_slot_staging/terragrunt.hcl
+++ b/prod/westeurope/linux/appbackendli/app_service_slot_staging/terragrunt.hcl
@@ -200,7 +200,7 @@ inputs = {
     MYPORTAL_BASE_PATH = "/myportal/api/v1"
 
     // MIT_VOUCHER JWT
-    JWT_MIT_VOUCHER_TOKEN_ISSUER=app-backend.io.italia.it
+    JWT_MIT_VOUCHER_TOKEN_ISSUER="app-backend.io.italia.it"
     JWT_MIT_VOUCHER_TOKEN_EXPIRATION=1200
 
     // BPD


### PR DESCRIPTION
Need some env variables for JWT API for MIT Voucher (called often "Sicilia Vola") to integrate remote SOGEI API by federation pattern.
You can read confluece pages: https://pagopa.atlassian.net/l/c/ovpwSi28

### List of changes

- IO BackEnd https://github.com/pagopa/io-backend/pull/807

### Motivation and context

Due a contract with MIT we need to implement a national service on IO App about flight vouchers for sicilian citizens. Origin backend was implemented by SOGEI and we need integrate a secure connection using a JWT.

### Type of changes

- [x] Add new resources
- [ ] Update configuration to existing resources
- [ ] Remove existing resources

### Does this introduce a change to production resources with possible user impact?

- [ ] Yes, users may be impacted applying this change
- [x] No

### Does this introduce an unwanted change on infrastructure? Check terraform plan execution result

- [ ] Yes
- [x] No

### Other information
no

### If PR is partially applied, why? (reserved to mantainers)

no