### PR TITLE
Enable fnapp FF_NEW_USERS_EUCOVIDCERT_ENABLED

### DIFF
--- a/prod/westeurope/functions_app1/functions_app1_r3/function_app/terragrunt.hcl
+++ b/prod/westeurope/functions_app1/functions_app1_r3/function_app/terragrunt.hcl
@@ -194,7 +194,7 @@ inputs = {
     # Limit the number of local services
     FF_LOCAL_SERVICES_LIMIT = "0"
     # eucovidcert configs
-    FF_NEW_USERS_EUCOVIDCERT_ENABLED       = "false"
+    FF_NEW_USERS_EUCOVIDCERT_ENABLED       = "true"
     EUCOVIDCERT_PROFILE_CREATED_QUEUE_NAME = dependency.storage_account_apievents_queue_eucovidcert-profile-created.outputs.name
 
     WEBSITE_CONTENTSHARE = "io-p-fn3-app1-content"

--- a/prod/westeurope/functions_app1/functions_app1_r3/function_app_slot_staging/terragrunt.hcl
+++ b/prod/westeurope/functions_app1/functions_app1_r3/function_app_slot_staging/terragrunt.hcl
@@ -170,7 +170,7 @@ inputs = {
     # Limit the number of local services
     FF_LOCAL_SERVICES_LIMIT = "0"
     # eucovidcert configs
-    FF_NEW_USERS_EUCOVIDCERT_ENABLED       = "false"
+    FF_NEW_USERS_EUCOVIDCERT_ENABLED       = "true"
     EUCOVIDCERT_PROFILE_CREATED_QUEUE_NAME = dependency.storage_account_apievents_queue_eucovidcert-profile-created.outputs.name
 
     # this app settings is required to solve the issue:

--- a/prod/westeurope/internal/api/functions_app2_r3/function_app/terragrunt.hcl
+++ b/prod/westeurope/internal/api/functions_app2_r3/function_app/terragrunt.hcl
@@ -193,7 +193,7 @@ inputs = {
     # Limit the number of local services
     FF_LOCAL_SERVICES_LIMIT = "0"
     # eucovidcert configs
-    FF_NEW_USERS_EUCOVIDCERT_ENABLED       = "false"
+    FF_NEW_USERS_EUCOVIDCERT_ENABLED       = "true"
     EUCOVIDCERT_PROFILE_CREATED_QUEUE_NAME = dependency.storage_account_apievents_queue_eucovidcert-profile-created.outputs.name
 
     WEBSITE_CONTENTSHARE = "io-p-fn3-app2-content"

--- a/prod/westeurope/internal/api/functions_app2_r3/function_app_slot_staging/terragrunt.hcl
+++ b/prod/westeurope/internal/api/functions_app2_r3/function_app_slot_staging/terragrunt.hcl
@@ -166,7 +166,7 @@ inputs = {
     # Limit the number of local services
     FF_LOCAL_SERVICES_LIMIT = "0"
     # eucovidcert configs
-    FF_NEW_USERS_EUCOVIDCERT_ENABLED       = "false"
+    FF_NEW_USERS_EUCOVIDCERT_ENABLED       = "true"
     EUCOVIDCERT_PROFILE_CREATED_QUEUE_NAME = dependency.storage_account_apievents_queue_eucovidcert-profile-created.outputs.name
 
     # this app settings is required to solve the issue:


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

### List of changes

- `FF_NEW_USERS_EUCOVIDCERT_ENABLED = true`

### Motivation and context

Enable Notify new users to DGC service

### Type of changes

- [ ] Add new resources
- [x] Update configuration to existing resources
- [ ] Remove existing resources

### Does this introduce a change to production resources with possible user impact?

- [ ] Yes, users may be impacted applying this change
- [x] No

### Does this introduce an unwanted change on infrastructure? Check terraform plan execution result

- [ ] Yes
- [x] No

### Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->

---

### If PR is partially applied, why? (reserved to mantainers)

Wait to apply this PR
