### PR TITLE
[#IPV-97] Add table storage to trace EU Covid Cert events

### DIFF
--- a/prod/westeurope/eucovidcert/functions_eucovidcert/function_app/terragrunt.hcl
+++ b/prod/westeurope/eucovidcert/functions_eucovidcert/function_app/terragrunt.hcl
@@ -14,6 +14,10 @@ dependency "storage_account_eucovidcert_queue_notify-new-profile" {
   config_path = "../../storage_eucovidcert/queue_notify-new-profile"
 }
 
+dependency "storage_account_eucovidcert_table_trace_notify-new-profile" {
+  config_path = "../../storage_eucovidcert/tabel_trace-notify-new-profile"
+}
+
 # Internal
 dependency "subnet_apimapi" {
   config_path = "../../../internal/api/apim/subnet/"
@@ -114,10 +118,12 @@ inputs = {
     DGC_PROD_URL      = "https://servizi-pn.dgc.gov.it"
     
     // Events configs
-    EventsQueueStorageConnection              = dependency.storage_account_apievents.outputs.primary_connection_string
-    EUCOVIDCERT_PROFILE_CREATED_QUEUE_NAME    = dependency.storage_account_apievents_queue_eucovidcert-profile-created.outputs.name
-    QueueStorageConnection                    = dependency.storage_account_eucovidcert.outputs.primary_connection_string
-    EUCOVIDCERT_NOTIFY_NEW_PROFILE_QUEUE_NAME = dependency.storage_account_eucovidcert_queue_notify-new-profile.outputs.name
+    EventsQueueStorageConnection                    = dependency.storage_account_apievents.outputs.primary_connection_string
+    EUCOVIDCERT_PROFILE_CREATED_QUEUE_NAME          = dependency.storage_account_apievents_queue_eucovidcert-profile-created.outputs.name
+    QueueStorageConnection                          = dependency.storage_account_eucovidcert.outputs.primary_connection_string
+    EUCOVIDCERT_NOTIFY_NEW_PROFILE_QUEUE_NAME       = dependency.storage_account_eucovidcert_queue_notify-new-profile.outputs.name
+    TableStorageConnection                          = dependency.storage_account_eucovidcert.outputs.primary_connection_string
+    EUCOVIDCERT_TRACE_NOTIFY_NEW_PROFILE_TABLE_NAME = dependency.storage_account_eucovidcert_table_trace-notify-new-profile.outputs.name
 
     SLOT_TASK_HUBNAME = "ProductionTaskHub"
 

--- a/prod/westeurope/eucovidcert/functions_eucovidcert/function_app/terragrunt.hcl
+++ b/prod/westeurope/eucovidcert/functions_eucovidcert/function_app/terragrunt.hcl
@@ -15,7 +15,7 @@ dependency "storage_account_eucovidcert_queue_notify-new-profile" {
 }
 
 dependency "storage_account_eucovidcert_table_trace_notify-new-profile" {
-  config_path = "../../storage_eucovidcert/tabel_trace-notify-new-profile"
+  config_path = "../../storage_eucovidcert/table-trace-notify-new-profile"
 }
 
 # Internal
@@ -123,7 +123,7 @@ inputs = {
     QueueStorageConnection                          = dependency.storage_account_eucovidcert.outputs.primary_connection_string
     EUCOVIDCERT_NOTIFY_NEW_PROFILE_QUEUE_NAME       = dependency.storage_account_eucovidcert_queue_notify-new-profile.outputs.name
     TableStorageConnection                          = dependency.storage_account_eucovidcert.outputs.primary_connection_string
-    EUCOVIDCERT_TRACE_NOTIFY_NEW_PROFILE_TABLE_NAME = dependency.storage_account_eucovidcert_table_trace-notify-new-profile.outputs.name
+    EUCOVIDCERT_TRACE_NOTIFY_NEW_PROFILE_TABLE_NAME = dependency.storage_account_eucovidcert_table_trace_notify-new-profile.outputs.name
 
     SLOT_TASK_HUBNAME = "ProductionTaskHub"
 

--- a/prod/westeurope/eucovidcert/functions_eucovidcert/function_app_slot_staging/terragrunt.hcl
+++ b/prod/westeurope/eucovidcert/functions_eucovidcert/function_app_slot_staging/terragrunt.hcl
@@ -18,6 +18,11 @@ dependency "storage_account_eucovidcert_queue_notify-new-profile" {
   config_path = "../../storage_eucovidcert/queue_notify-new-profile"
 }
 
+dependency "storage_account_eucovidcert_table_trace_notify-new-profile" {
+  config_path = "../../storage_eucovidcert/tabel_trace-notify-new-profile"
+}
+
+
 # Internal
 dependency "subnet_apimapi" {
   config_path = "../../../internal/api/apim/subnet/"
@@ -123,10 +128,12 @@ inputs = {
     DGC_PROD_URL      = "https://servizi-pn.dgc.gov.it"
 
     // Events configs
-    EventsQueueStorageConnection              = dependency.storage_account_apievents.outputs.primary_connection_string
-    EUCOVIDCERT_PROFILE_CREATED_QUEUE_NAME    = dependency.storage_account_apievents_queue_eucovidcert-profile-created.outputs.name
-    QueueStorageConnection                    = dependency.storage_account_eucovidcert.outputs.primary_connection_string
-    EUCOVIDCERT_NOTIFY_NEW_PROFILE_QUEUE_NAME = dependency.storage_account_eucovidcert_queue_notify-new-profile.outputs.name
+    EventsQueueStorageConnection                    = dependency.storage_account_apievents.outputs.primary_connection_string
+    EUCOVIDCERT_PROFILE_CREATED_QUEUE_NAME          = dependency.storage_account_apievents_queue_eucovidcert-profile-created.outputs.name
+    QueueStorageConnection                          = dependency.storage_account_eucovidcert.outputs.primary_connection_string
+    EUCOVIDCERT_NOTIFY_NEW_PROFILE_QUEUE_NAME       = dependency.storage_account_eucovidcert_queue_notify-new-profile.outputs.name
+    TableStorageConnection                          = dependency.storage_account_eucovidcert.outputs.primary_connection_string
+    EUCOVIDCERT_TRACE_NOTIFY_NEW_PROFILE_TABLE_NAME = dependency.storage_account_eucovidcert_table_trace-notify-new-profile.outputs.name
 
     SLOT_TASK_HUBNAME = "StagingTaskHub"
 

--- a/prod/westeurope/eucovidcert/functions_eucovidcert/function_app_slot_staging/terragrunt.hcl
+++ b/prod/westeurope/eucovidcert/functions_eucovidcert/function_app_slot_staging/terragrunt.hcl
@@ -19,7 +19,7 @@ dependency "storage_account_eucovidcert_queue_notify-new-profile" {
 }
 
 dependency "storage_account_eucovidcert_table_trace_notify-new-profile" {
-  config_path = "../../storage_eucovidcert/tabel_trace-notify-new-profile"
+  config_path = "../../storage_eucovidcert/table-trace-notify-new-profile"
 }
 
 
@@ -133,7 +133,7 @@ inputs = {
     QueueStorageConnection                          = dependency.storage_account_eucovidcert.outputs.primary_connection_string
     EUCOVIDCERT_NOTIFY_NEW_PROFILE_QUEUE_NAME       = dependency.storage_account_eucovidcert_queue_notify-new-profile.outputs.name
     TableStorageConnection                          = dependency.storage_account_eucovidcert.outputs.primary_connection_string
-    EUCOVIDCERT_TRACE_NOTIFY_NEW_PROFILE_TABLE_NAME = dependency.storage_account_eucovidcert_table_trace-notify-new-profile.outputs.name
+    EUCOVIDCERT_TRACE_NOTIFY_NEW_PROFILE_TABLE_NAME = dependency.storage_account_eucovidcert_table_trace_notify-new-profile.outputs.name
 
     SLOT_TASK_HUBNAME = "StagingTaskHub"
 

--- a/prod/westeurope/eucovidcert/storage_eucovidcert/table-trace-notify-new-profile/terragrunt.hcl
+++ b/prod/westeurope/eucovidcert/storage_eucovidcert/table-trace-notify-new-profile/terragrunt.hcl
@@ -1,0 +1,17 @@
+dependency "storage_account" {
+  config_path = "../account"
+}
+
+# Include all settings from the root terragrunt.hcl file
+include {
+  path = find_in_parent_folders()
+}
+
+terraform {
+  source = "git::git@github.com:pagopa/io-infrastructure-modules-new.git//azurerm_storage_table?ref=v3.0.3"
+}
+
+inputs = {
+  name                  = "trace-notify-new-profile"
+  storage_account_name  = dependency.storage_account.outputs.resource_name
+}

--- a/prod/westeurope/eucovidcert/storage_eucovidcert/table-trace-notify-new-profile/terragrunt.hcl
+++ b/prod/westeurope/eucovidcert/storage_eucovidcert/table-trace-notify-new-profile/terragrunt.hcl
@@ -12,6 +12,6 @@ terraform {
 }
 
 inputs = {
-  name                  = "trace-notify-new-profile"
+  name                  = "TraceNotifyNewProfile"
   storage_account_name  = dependency.storage_account.outputs.resource_name
 }


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

### List of changes

<!--- Describe your changes in detail -->
* create table `trace-notify-new-profile` into `iopsteucovidcert`
* reference the table in app using env var

### Motivation and context

<!--- Why is this change required? What problem does it solve? -->
For easy support and throubleshooting, we will need to trace all events occurred in the process of notify a new profile to DGC

### Type of changes

- [x] Add new resources
- [x] Update configuration to existing resources
- [ ] Remove existing resources

### Does this introduce a change to production resources with possible user impact?

- [ ] Yes, users may be impacted applying this change
- [x] No

### Does this introduce an unwanted change on infrastructure? Check terraform plan execution result

- [ ] Yes
- [x] No

### Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->

---

### If PR is partially applied, why? (reserved to mantainers)

<!--- Describe the blocking cause -->
