### PR TITLE
fix notification-status

### DIFF
--- a/prod/westeurope/internal/api/cosmosdb/container_notification-status/terragrunt.hcl
+++ b/prod/westeurope/internal/api/cosmosdb/container_notification-status/terragrunt.hcl
@@ -28,6 +28,6 @@ inputs = {
   partition_key_path  = "/notificationId"
 
   autoscale_settings = {
-    max_throughput = 7000
+    max_throughput = 10000
   }
 }


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

### List of changes

Set max_throughput to previous value: 10000
No apply needed

### Motivation and context

Apply fail with this error:
The offer should have valid throughput values between 12000 and 1000000 inclusive in increments of 1000.

Notification status is now 97GB so probably we can't scale down to 7000 RU/s
https://docs.microsoft.com/en-us/azure/cosmos-db/concepts-limits#limits-for-autoscale-provisioned-throughput

### Type of changes

- [ ] Add new resources
- [ ] Update configuration to existing resources
- [ ] Remove existing resources

### Does this introduce a change to production resources with possible user impact?

- [ ] Yes, users may be impacted applying this change
- [x] No

### Does this introduce an unwanted change on infrastructure? Check terraform plan execution result

- [ ] Yes
- [x] No

### Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->

---

### If PR is partially applied, why? (reserved to mantainers)

<!--- Describe the blocking cause -->
