### PR TITLE
[#IOINFRA-173] Configure functions's routing and DNS to access cosmos-api

### DIFF
--- a/prod/westeurope/functions_app1/functions_app1_r3/function_app/terragrunt.hcl
+++ b/prod/westeurope/functions_app1/functions_app1_r3/function_app/terragrunt.hcl
@@ -134,6 +134,10 @@ inputs = {
     FUNCTIONS_WORKER_PROCESS_COUNT = 4
     NODE_ENV                       = "production"
 
+    # DNS and VNET configuration to use private endpoint
+    WEBSITE_DNS_SERVER     = "168.63.129.16"
+    WEBSITE_VNET_ROUTE_ALL = 1
+
     COSMOSDB_URI  = dependency.cosmosdb_account.outputs.endpoint
     COSMOSDB_KEY  = dependency.cosmosdb_account.outputs.primary_master_key
     COSMOSDB_NAME = dependency.cosmosdb_database.outputs.name
@@ -215,7 +219,6 @@ inputs = {
     FF_OPT_IN_EMAIL_ENABLED   = local.ff_opt_in_email_enabled
 
     WEBSITE_CONTENTSHARE = "io-p-fn3-app1-content"
-
   }
 
   app_settings_secrets = {

--- a/prod/westeurope/functions_app1/functions_app1_r3/function_app_slot_staging/terragrunt.hcl
+++ b/prod/westeurope/functions_app1/functions_app1_r3/function_app_slot_staging/terragrunt.hcl
@@ -136,6 +136,10 @@ inputs = {
     FUNCTIONS_WORKER_PROCESS_COUNT = 4
     NODE_ENV                       = "production"
 
+    # DNS and VNET configuration to use private endpoint
+    WEBSITE_DNS_SERVER     = "168.63.129.16"
+    WEBSITE_VNET_ROUTE_ALL = 1
+
     COSMOSDB_URI  = dependency.cosmosdb_account.outputs.endpoint
     COSMOSDB_KEY  = dependency.cosmosdb_account.outputs.primary_master_key
     COSMOSDB_NAME = dependency.cosmosdb_database.outputs.name

--- a/prod/westeurope/internal/api/functions_admin_r3/function_app/terragrunt.hcl
+++ b/prod/westeurope/internal/api/functions_admin_r3/function_app/terragrunt.hcl
@@ -110,6 +110,10 @@ inputs = {
     WEBSITE_RUN_FROM_PACKAGE     = "1"
     NODE_ENV                     = "production"
 
+    # DNS and VNET configuration to use private endpoint
+    WEBSITE_DNS_SERVER     = "168.63.129.16"
+    WEBSITE_VNET_ROUTE_ALL = 1
+
     COSMOSDB_URI               = dependency.cosmosdb_account.outputs.endpoint
     COSMOSDB_KEY               = dependency.cosmosdb_account.outputs.primary_master_key
     COSMOSDB_NAME              = dependency.cosmosdb_database.outputs.name

--- a/prod/westeurope/internal/api/functions_admin_r3/function_app_slot_staging/terragrunt.hcl
+++ b/prod/westeurope/internal/api/functions_admin_r3/function_app_slot_staging/terragrunt.hcl
@@ -112,6 +112,10 @@ inputs = {
     WEBSITE_RUN_FROM_PACKAGE     = "1"
     NODE_ENV                     = "production"
 
+    # DNS and VNET configuration to use private endpoint
+    WEBSITE_DNS_SERVER     = "168.63.129.16"
+    WEBSITE_VNET_ROUTE_ALL = 1
+
     COSMOSDB_URI               = dependency.cosmosdb_account.outputs.endpoint
     COSMOSDB_KEY               = dependency.cosmosdb_account.outputs.primary_master_key
     COSMOSDB_NAME              = dependency.cosmosdb_database.outputs.name

--- a/prod/westeurope/internal/api/functions_app2_r3/function_app/terragrunt.hcl
+++ b/prod/westeurope/internal/api/functions_app2_r3/function_app/terragrunt.hcl
@@ -133,6 +133,10 @@ inputs = {
     FUNCTIONS_WORKER_PROCESS_COUNT = 4
     NODE_ENV                       = "production"
 
+    # DNS and VNET configuration to use private endpoint
+    WEBSITE_DNS_SERVER     = "168.63.129.16"
+    WEBSITE_VNET_ROUTE_ALL = 1
+
     COSMOSDB_URI  = dependency.cosmosdb_account.outputs.endpoint
     COSMOSDB_KEY  = dependency.cosmosdb_account.outputs.primary_master_key
     COSMOSDB_NAME = dependency.cosmosdb_database.outputs.name

--- a/prod/westeurope/internal/api/functions_app2_r3/function_app_slot_staging/terragrunt.hcl
+++ b/prod/westeurope/internal/api/functions_app2_r3/function_app_slot_staging/terragrunt.hcl
@@ -132,6 +132,10 @@ inputs = {
     FUNCTIONS_WORKER_PROCESS_COUNT = 4
     NODE_ENV                       = "production"
 
+    # DNS and VNET configuration to use private endpoint
+    WEBSITE_DNS_SERVER     = "168.63.129.16"
+    WEBSITE_VNET_ROUTE_ALL = 1
+
     COSMOSDB_URI  = dependency.cosmosdb_account.outputs.endpoint
     COSMOSDB_KEY  = dependency.cosmosdb_account.outputs.primary_master_key
     COSMOSDB_NAME = dependency.cosmosdb_database.outputs.name

--- a/prod/westeurope/internal/api/functions_app_async/function_app/terragrunt.hcl
+++ b/prod/westeurope/internal/api/functions_app_async/function_app/terragrunt.hcl
@@ -133,6 +133,10 @@ inputs = {
     FUNCTIONS_WORKER_PROCESS_COUNT = 4
     NODE_ENV                       = "production"
 
+    # DNS and VNET configuration to use private endpoint
+    WEBSITE_DNS_SERVER     = "168.63.129.16"
+    WEBSITE_VNET_ROUTE_ALL = 1
+
     COSMOSDB_URI  = dependency.cosmosdb_account.outputs.endpoint
     COSMOSDB_KEY  = dependency.cosmosdb_account.outputs.primary_master_key
     COSMOSDB_NAME = dependency.cosmosdb_database.outputs.name

--- a/prod/westeurope/internal/api/functions_app_async/function_app_slot_staging/terragrunt.hcl
+++ b/prod/westeurope/internal/api/functions_app_async/function_app_slot_staging/terragrunt.hcl
@@ -132,6 +132,10 @@ inputs = {
     FUNCTIONS_WORKER_PROCESS_COUNT = 4
     NODE_ENV                       = "production"
 
+    # DNS and VNET configuration to use private endpoint
+    WEBSITE_DNS_SERVER     = "168.63.129.16"
+    WEBSITE_VNET_ROUTE_ALL = 1
+
     COSMOSDB_URI  = dependency.cosmosdb_account.outputs.endpoint
     COSMOSDB_KEY  = dependency.cosmosdb_account.outputs.primary_master_key
     COSMOSDB_NAME = dependency.cosmosdb_database.outputs.name

--- a/prod/westeurope/internal/api/functions_assets_r3/function_app/terragrunt.hcl
+++ b/prod/westeurope/internal/api/functions_assets_r3/function_app/terragrunt.hcl
@@ -76,6 +76,10 @@ inputs = {
     FUNCTIONS_WORKER_PROCESS_COUNT = 4
     NODE_ENV                       = "production"
 
+    # DNS and VNET configuration to use private endpoint
+    WEBSITE_DNS_SERVER     = "168.63.129.16"
+    WEBSITE_VNET_ROUTE_ALL = 1
+
     APPINSIGHTS_SAMPLING_PERCENTAGE = "5"
 
     COSMOSDB_URI  = dependency.cosmosdb_account.outputs.endpoint

--- a/prod/westeurope/internal/api/functions_assets_r3/function_app_slot_staging/terragrunt.hcl
+++ b/prod/westeurope/internal/api/functions_assets_r3/function_app_slot_staging/terragrunt.hcl
@@ -77,6 +77,10 @@ inputs = {
     FUNCTIONS_WORKER_PROCESS_COUNT = 4
     NODE_ENV                       = "production"
 
+    # DNS and VNET configuration to use private endpoint
+    WEBSITE_DNS_SERVER     = "168.63.129.16"
+    WEBSITE_VNET_ROUTE_ALL = 1
+
     APPINSIGHTS_SAMPLING_PERCENTAGE = "5"
 
     COSMOSDB_URI  = dependency.cosmosdb_account.outputs.endpoint

--- a/prod/westeurope/internal/api/functions_public_r3/function_app/terragrunt.hcl
+++ b/prod/westeurope/internal/api/functions_public_r3/function_app/terragrunt.hcl
@@ -76,6 +76,10 @@ inputs = {
     WEBSITE_RUN_FROM_PACKAGE     = "1"
     NODE_ENV                     = "production"
 
+    # DNS and VNET configuration to use private endpoint
+    WEBSITE_DNS_SERVER     = "168.63.129.16"
+    WEBSITE_VNET_ROUTE_ALL = 1
+
     COSMOSDB_URI      = dependency.cosmosdb_account.outputs.endpoint
     COSMOSDB_KEY      = dependency.cosmosdb_account.outputs.primary_master_key
     COSMOSDB_NAME     = dependency.cosmosdb_database.outputs.name

--- a/prod/westeurope/internal/api/functions_public_r3/function_app_slot_staging/terragrunt.hcl
+++ b/prod/westeurope/internal/api/functions_public_r3/function_app_slot_staging/terragrunt.hcl
@@ -73,6 +73,10 @@ inputs = {
     WEBSITE_RUN_FROM_PACKAGE     = "1"
     NODE_ENV                     = "production"
 
+    # DNS and VNET configuration to use private endpoint
+    WEBSITE_DNS_SERVER     = "168.63.129.16"
+    WEBSITE_VNET_ROUTE_ALL = 1
+
     COSMOSDB_URI      = dependency.cosmosdb_account.outputs.endpoint
     COSMOSDB_KEY      = dependency.cosmosdb_account.outputs.primary_master_key
     COSMOSDB_NAME     = dependency.cosmosdb_database.outputs.name

--- a/prod/westeurope/internal/api/functions_services_r3/function_app/terragrunt.hcl
+++ b/prod/westeurope/internal/api/functions_services_r3/function_app/terragrunt.hcl
@@ -91,6 +91,10 @@ inputs = {
     FUNCTIONS_WORKER_PROCESS_COUNT = 4
     NODE_ENV                       = "production"
 
+    # DNS and VNET configuration to use private endpoint
+    WEBSITE_DNS_SERVER     = "168.63.129.16"
+    WEBSITE_VNET_ROUTE_ALL = 1
+
     COSMOSDB_URI  = dependency.cosmosdb_account.outputs.endpoint
     COSMOSDB_KEY  = dependency.cosmosdb_account.outputs.primary_master_key
     COSMOSDB_NAME = dependency.cosmosdb_database.outputs.name

--- a/prod/westeurope/internal/api/functions_services_r3/function_app_slot_staging/terragrunt.hcl
+++ b/prod/westeurope/internal/api/functions_services_r3/function_app_slot_staging/terragrunt.hcl
@@ -91,6 +91,10 @@ inputs = {
     FUNCTIONS_WORKER_PROCESS_COUNT = 4
     NODE_ENV                       = "production"
 
+    # DNS and VNET configuration to use private endpoint
+    WEBSITE_DNS_SERVER     = "168.63.129.16"
+    WEBSITE_VNET_ROUTE_ALL = 1
+
     COSMOSDB_URI  = dependency.cosmosdb_account.outputs.endpoint
     COSMOSDB_KEY  = dependency.cosmosdb_account.outputs.primary_master_key
     COSMOSDB_NAME = dependency.cosmosdb_database.outputs.name

--- a/prod/westeurope/internal/api/functions_servicescache_r3/function_app/terragrunt.hcl
+++ b/prod/westeurope/internal/api/functions_servicescache_r3/function_app/terragrunt.hcl
@@ -74,6 +74,10 @@ inputs = {
     WEBSITE_RUN_FROM_PACKAGE     = "1"
     NODE_ENV                     = "production"
 
+    # DNS and VNET configuration to use private endpoint
+    WEBSITE_DNS_SERVER     = "168.63.129.16"
+    WEBSITE_VNET_ROUTE_ALL = 1
+
     COSMOSDB_URI               = dependency.cosmosdb_account.outputs.endpoint
     COSMOSDB_KEY               = dependency.cosmosdb_account.outputs.primary_master_key
     COSMOSDB_NAME              = dependency.cosmosdb_database.outputs.name

--- a/prod/westeurope/internal/api/functions_servicescache_r3/function_app_slot_staging/terragrunt.hcl
+++ b/prod/westeurope/internal/api/functions_servicescache_r3/function_app_slot_staging/terragrunt.hcl
@@ -73,6 +73,10 @@ inputs = {
     WEBSITE_RUN_FROM_PACKAGE     = "1"
     NODE_ENV                     = "production"
 
+    # DNS and VNET configuration to use private endpoint
+    WEBSITE_DNS_SERVER     = "168.63.129.16"
+    WEBSITE_VNET_ROUTE_ALL = 1
+
     COSMOSDB_URI               = dependency.cosmosdb_account.outputs.endpoint
     COSMOSDB_KEY               = dependency.cosmosdb_account.outputs.primary_master_key
     COSMOSDB_NAME              = dependency.cosmosdb_database.outputs.name

--- a/prod/westeurope/services/functions_services01_r3/function_app/terragrunt.hcl
+++ b/prod/westeurope/services/functions_services01_r3/function_app/terragrunt.hcl
@@ -92,6 +92,10 @@ inputs = {
     FUNCTIONS_WORKER_PROCESS_COUNT = 4
     NODE_ENV                       = "production"
 
+    # DNS and VNET configuration to use private endpoint
+    WEBSITE_DNS_SERVER     = "168.63.129.16"
+    WEBSITE_VNET_ROUTE_ALL = 1
+
     COSMOSDB_URI  = dependency.cosmosdb_account.outputs.endpoint
     COSMOSDB_KEY  = dependency.cosmosdb_account.outputs.primary_master_key
     COSMOSDB_NAME = dependency.cosmosdb_database.outputs.name

--- a/prod/westeurope/services/functions_services01_r3/function_app_slot_staging/terragrunt.hcl
+++ b/prod/westeurope/services/functions_services01_r3/function_app_slot_staging/terragrunt.hcl
@@ -92,6 +92,10 @@ inputs = {
     FUNCTIONS_WORKER_PROCESS_COUNT = 4
     NODE_ENV                       = "production"
 
+    # DNS and VNET configuration to use private endpoint
+    WEBSITE_DNS_SERVER     = "168.63.129.16"
+    WEBSITE_VNET_ROUTE_ALL = 1
+
     COSMOSDB_URI  = dependency.cosmosdb_account.outputs.endpoint
     COSMOSDB_KEY  = dependency.cosmosdb_account.outputs.primary_master_key
     COSMOSDB_NAME = dependency.cosmosdb_database.outputs.name


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

### List of changes

add azure functions app settings to route all traffic in private VNET using private dns zones

```
    # DNS and VNET configuration to use private endpoint
    WEBSITE_DNS_SERVER     = "168.63.129.16"
    WEBSITE_VNET_ROUTE_ALL = 1
```

### Motivation and context

limits comosapi network access

### Type of changes

- [ ] Add new resources
- [x] Update configuration to existing resources
- [ ] Remove existing resources

### Does this introduce a change to production resources with possible user impact?

- [x] Yes, users may be impacted applying this change
- [ ] No

### Does this introduce an unwanted change on infrastructure? Check terraform plan execution result

- [ ] Yes
- [x] No

### Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->

---

### If PR is partially applied, why? (reserved to mantainers)

<!--- Describe the blocking cause -->
