### PR TITLE
Add dns forwarder in vpnp2s vnet

### DIFF
--- a/prod/westeurope/common/private_dns_zones/privatelink-blob-core-windows-net/virtual_network_link_vnet-vpnp2s/terragrunt.hcl
+++ b/prod/westeurope/common/private_dns_zones/privatelink-blob-core-windows-net/virtual_network_link_vnet-vpnp2s/terragrunt.hcl
@@ -7,7 +7,7 @@ dependency "resource_group" {
 }
 
 dependency "virtual_network" {
-  config_path = "../../../virtual_network"
+  config_path = "../../../../vpnp2s/virtual_network"
 }
 
 

--- a/prod/westeurope/common/private_dns_zones/privatelink-documents-azure-com/virtual_network_link_vnet-common/terragrunt.hcl
+++ b/prod/westeurope/common/private_dns_zones/privatelink-documents-azure-com/virtual_network_link_vnet-common/terragrunt.hcl
@@ -23,6 +23,6 @@ terraform {
 inputs = {
   name                  = dependency.virtual_network.outputs.resource_name
   private_dns_zone_name = dependency.private_dns_zone.outputs.name
-  resource_group_name   = dependency.resource_group.outputs.resource_name
+  resource_group_name   = dependency.resource_group.outputs.resource_name # must be dns_zone resource_group
   virtual_network_id    = dependency.virtual_network.outputs.id
 }

--- a/prod/westeurope/common/private_dns_zones/privatelink-documents-azure-com/virtual_network_link_vnet-vpnp2s/terragrunt.hcl
+++ b/prod/westeurope/common/private_dns_zones/privatelink-documents-azure-com/virtual_network_link_vnet-vpnp2s/terragrunt.hcl
@@ -7,7 +7,7 @@ dependency "resource_group" {
 }
 
 dependency "virtual_network" {
-  config_path = "../../../virtual_network"
+  config_path = "../../../../vpnp2s/virtual_network"
 }
 
 

--- a/prod/westeurope/common/private_dns_zones/privatelink-file-core-windows-net/virtual_network_link_vnet-common/terragrunt.hcl
+++ b/prod/westeurope/common/private_dns_zones/privatelink-file-core-windows-net/virtual_network_link_vnet-common/terragrunt.hcl
@@ -23,6 +23,6 @@ terraform {
 inputs = {
   name                  = dependency.virtual_network.outputs.resource_name
   private_dns_zone_name = dependency.private_dns_zone.outputs.name
-  resource_group_name   = dependency.resource_group.outputs.resource_name
+  resource_group_name   = dependency.resource_group.outputs.resource_name # must be dns_zone resource_group
   virtual_network_id    = dependency.virtual_network.outputs.id
 }

--- a/prod/westeurope/common/private_dns_zones/privatelink-file-core-windows-net/virtual_network_link_vnet-vpnp2s/terragrunt.hcl
+++ b/prod/westeurope/common/private_dns_zones/privatelink-file-core-windows-net/virtual_network_link_vnet-vpnp2s/terragrunt.hcl
@@ -7,7 +7,7 @@ dependency "resource_group" {
 }
 
 dependency "virtual_network" {
-  config_path = "../../../virtual_network"
+  config_path = "../../../../vpnp2s/virtual_network"
 }
 
 

--- a/prod/westeurope/common/private_dns_zones/privatelink-queue-core-windows-net/virtual_network_link_vnet-common/terragrunt.hcl
+++ b/prod/westeurope/common/private_dns_zones/privatelink-queue-core-windows-net/virtual_network_link_vnet-common/terragrunt.hcl
@@ -23,6 +23,6 @@ terraform {
 inputs = {
   name                  = dependency.virtual_network.outputs.resource_name
   private_dns_zone_name = dependency.private_dns_zone.outputs.name
-  resource_group_name   = dependency.resource_group.outputs.resource_name
+  resource_group_name   = dependency.resource_group.outputs.resource_name # must be dns_zone resource_group
   virtual_network_id    = dependency.virtual_network.outputs.id
 }

--- a/prod/westeurope/common/private_dns_zones/privatelink-queue-core-windows-net/virtual_network_link_vnet-vpnp2s/terragrunt.hcl
+++ b/prod/westeurope/common/private_dns_zones/privatelink-queue-core-windows-net/virtual_network_link_vnet-vpnp2s/terragrunt.hcl
@@ -7,7 +7,7 @@ dependency "resource_group" {
 }
 
 dependency "virtual_network" {
-  config_path = "../../../virtual_network"
+  config_path = "../../../../vpnp2s/virtual_network"
 }
 
 

--- a/prod/westeurope/common/private_dns_zones/privatelink-table-core-windows-net/virtual_network_link_vnet-common/terragrunt.hcl
+++ b/prod/westeurope/common/private_dns_zones/privatelink-table-core-windows-net/virtual_network_link_vnet-common/terragrunt.hcl
@@ -23,6 +23,6 @@ terraform {
 inputs = {
   name                  = dependency.virtual_network.outputs.resource_name
   private_dns_zone_name = dependency.private_dns_zone.outputs.name
-  resource_group_name   = dependency.resource_group.outputs.resource_name
+  resource_group_name   = dependency.resource_group.outputs.resource_name # must be dns_zone resource_group
   virtual_network_id    = dependency.virtual_network.outputs.id
 }

--- a/prod/westeurope/common/private_dns_zones/privatelink-table-core-windows-net/virtual_network_link_vnet-vpnp2s/terragrunt.hcl
+++ b/prod/westeurope/common/private_dns_zones/privatelink-table-core-windows-net/virtual_network_link_vnet-vpnp2s/terragrunt.hcl
@@ -7,7 +7,7 @@ dependency "resource_group" {
 }
 
 dependency "virtual_network" {
-  config_path = "../../../virtual_network"
+  config_path = "../../../../vpnp2s/virtual_network"
 }
 
 

--- a/prod/westeurope/vpnp2s/dns_forwarder/server/terragrunt.hcl
+++ b/prod/westeurope/vpnp2s/dns_forwarder/server/terragrunt.hcl
@@ -1,0 +1,22 @@
+dependency "virtual_network" {
+  config_path = "../../virtual_network"
+}
+
+dependency "subnet" {
+  config_path = "../subnet"
+}
+
+# Include all settings from the root terragrunt.hcl file
+include {
+  path = find_in_parent_folders()
+}
+
+terraform {
+  source = "git::git@github.com:pagopa/io-infrastructure-modules-new.git//azurerm_dns_forwarder?ref=v3.0.9"
+}
+
+inputs = {
+  name                = "dns-forwarder-vpnp2s"
+  resource_group_name = dependency.virtual_network.outputs.resource_group_name
+  subnet_id           = dependency.subnet.outputs.id
+}

--- a/prod/westeurope/vpnp2s/dns_forwarder/subnet/terragrunt.hcl
+++ b/prod/westeurope/vpnp2s/dns_forwarder/subnet/terragrunt.hcl
@@ -1,0 +1,30 @@
+dependency "virtual_network" {
+  config_path = "../../virtual_network"
+}
+
+# Include all settings from the root terragrunt.hcl file
+include {
+  path = find_in_parent_folders()
+}
+
+terraform {
+  source = "git::git@github.com:pagopa/io-infrastructure-modules-new.git//azurerm_subnet?ref=v3.0.3"
+}
+
+inputs = {
+  name = "dns-forwarder"
+
+  resource_group_name                            = dependency.virtual_network.outputs.resource_group_name
+  virtual_network_name                           = dependency.virtual_network.outputs.resource_name
+  address_prefix                                 = "10.1.252.0/29"
+  enforce_private_link_endpoint_network_policies = true
+
+  delegation = {
+    name = "delegation"
+    service_delegation = {
+      name    = "Microsoft.ContainerInstance/containerGroups"
+      actions = ["Microsoft.Network/virtualNetworks/subnets/action"]
+    }
+  }
+
+}

--- a/prod/westeurope/vpnp2s/resource_group/terragrunt.hcl
+++ b/prod/westeurope/vpnp2s/resource_group/terragrunt.hcl
@@ -1,0 +1,12 @@
+# Include all settings from the root terragrunt.hcl file
+include {
+  path = find_in_parent_folders()
+}
+
+terraform {
+  source = "git::git@github.com:pagopa/io-infrastructure-modules-new.git//azurerm_resource_group?ref=v3.0.3"
+}
+
+inputs = {
+  name = "vpnp2s"
+}

--- a/prod/westeurope/vpnp2s/virtual_network/terragrunt.hcl
+++ b/prod/westeurope/vpnp2s/virtual_network/terragrunt.hcl
@@ -1,0 +1,18 @@
+dependency "resource_group" {
+  config_path = "../resource_group"
+}
+
+# Include all settings from the root terragrunt.hcl file
+include {
+  path = find_in_parent_folders()
+}
+
+terraform {
+  source = "git::git@github.com:pagopa/io-infrastructure-modules-new.git//azurerm_virtual_network?ref=v3.0.3"
+}
+
+inputs = {
+  name                = "vpnp2s"
+  resource_group_name = dependency.resource_group.outputs.resource_name
+  address_space       = ["10.1.0.0/16"]
+}


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

### List of changes

- add resource group vpnp2s (imported)
- add vnet vpnp2s (imported)
- add dns forwarder vpnp2s
- add vpnp2s private links to private dns zones

### Motivation and context

now dns forwarder works even if vnet-common is in maintenance mode

### Type of changes

- [x] Add new resources
- [ ] Update configuration to existing resources
- [ ] Remove existing resources

### Does this introduce a change to production resources with possible user impact?

- [ ] Yes, users may be impacted applying this change
- [x] No

### Does this introduce an unwanted change on infrastructure? Check terraform plan execution result

- [ ] Yes
- [x] No

### Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->

---

### If PR is partially applied, why? (reserved to mantainers)

<!--- Describe the blocking cause -->
