### PR TITLE
[#IOINFRA-184] Add whitelist resources to access iopstapi

### DIFF
--- a/prod/westeurope/functions_app1/functions_app1_r3/subnet/terragrunt.hcl
+++ b/prod/westeurope/functions_app1/functions_app1_r3/subnet/terragrunt.hcl
@@ -30,6 +30,7 @@ inputs = {
 
   service_endpoints = [
     "Microsoft.Web",
-    "Microsoft.AzureCosmosDB"
+    "Microsoft.AzureCosmosDB",
+    "Microsoft.Storage",
   ]
 }

--- a/prod/westeurope/internal/api/functions_admin_r3/subnet/terragrunt.hcl
+++ b/prod/westeurope/internal/api/functions_admin_r3/subnet/terragrunt.hcl
@@ -30,6 +30,7 @@ inputs = {
 
   service_endpoints = [
     "Microsoft.Web",
-    "Microsoft.AzureCosmosDB"
+    "Microsoft.AzureCosmosDB",
+    "Microsoft.Storage",
   ]
 }

--- a/prod/westeurope/internal/api/functions_app2_r3/subnet/terragrunt.hcl
+++ b/prod/westeurope/internal/api/functions_app2_r3/subnet/terragrunt.hcl
@@ -30,6 +30,7 @@ inputs = {
 
   service_endpoints = [
     "Microsoft.Web",
-    "Microsoft.AzureCosmosDB"
+    "Microsoft.AzureCosmosDB",
+    "Microsoft.Storage",
   ]
 }

--- a/prod/westeurope/internal/api/functions_app_async/subnet/terragrunt.hcl
+++ b/prod/westeurope/internal/api/functions_app_async/subnet/terragrunt.hcl
@@ -30,6 +30,7 @@ inputs = {
 
   service_endpoints = [
     "Microsoft.Web",
-    "Microsoft.AzureCosmosDB"
+    "Microsoft.AzureCosmosDB",
+    "Microsoft.Storage",
   ]
 }

--- a/prod/westeurope/internal/api/functions_assets_r3/subnet/terragrunt.hcl
+++ b/prod/westeurope/internal/api/functions_assets_r3/subnet/terragrunt.hcl
@@ -31,5 +31,6 @@ inputs = {
   service_endpoints = [
     "Microsoft.Web",
     "Microsoft.AzureCosmosDB",
+    "Microsoft.Storage",
   ]
 }

--- a/prod/westeurope/internal/api/functions_public_r3/subnet/terragrunt.hcl
+++ b/prod/westeurope/internal/api/functions_public_r3/subnet/terragrunt.hcl
@@ -30,6 +30,7 @@ inputs = {
 
   service_endpoints = [
     "Microsoft.Web",
-    "Microsoft.AzureCosmosDB"
+    "Microsoft.AzureCosmosDB",
+    "Microsoft.Storage",
   ]
 }

--- a/prod/westeurope/internal/api/functions_services_r3/subnet/terragrunt.hcl
+++ b/prod/westeurope/internal/api/functions_services_r3/subnet/terragrunt.hcl
@@ -30,6 +30,7 @@ inputs = {
 
   service_endpoints = [
     "Microsoft.Web",
-    "Microsoft.AzureCosmosDB"
+    "Microsoft.AzureCosmosDB",
+    "Microsoft.Storage",
   ]
 }

--- a/prod/westeurope/internal/api/functions_servicescache_r3/subnet/terragrunt.hcl
+++ b/prod/westeurope/internal/api/functions_servicescache_r3/subnet/terragrunt.hcl
@@ -30,6 +30,7 @@ inputs = {
 
   service_endpoints = [
     "Microsoft.Web",
-    "Microsoft.AzureCosmosDB"
+    "Microsoft.AzureCosmosDB",
+    "Microsoft.Storage",
   ]
 }

--- a/prod/westeurope/internal/api/storage/account/terragrunt.hcl
+++ b/prod/westeurope/internal/api/storage/account/terragrunt.hcl
@@ -3,6 +3,42 @@ dependency "resource_group" {
   config_path = "../../../resource_group"
 }
 
+dependency "subnet_fn_admin" {
+  config_path = "../../functions_admin_r3/subnet"
+}
+
+dependency "subnet_fn_appasync" {
+  config_path = "../../functions_app_async/subnet"
+}
+
+dependency "subnet_fn_app1" {
+  config_path = "../../../../functions_app1/functions_app1_r3/subnet"
+}
+
+dependency "subnet_fn_app2" {
+  config_path = "../../functions_app2_r3/subnet"
+}
+
+dependency "subnet_fn_assets" {
+  config_path = "../../functions_assets_r3/subnet"
+}
+
+dependency "subnet_fn_public" {
+  config_path = "../../functions_public_r3/subnet"
+}
+
+dependency "subnet_fn_services" {
+  config_path = "../../functions_services_r3/subnet"
+}
+
+dependency "subnet_fn_services01" {
+  config_path = "../../../../services/functions_services01_r3/subnet"
+}
+
+dependency "subnet_fn_servicescache" {
+  config_path = "../../functions_servicescache_r3/subnet"
+}
+
 # Include all settings from the root terragrunt.hcl file
 include {
   path = find_in_parent_folders()
@@ -20,4 +56,25 @@ inputs = {
   account_replication_type = "GRS"
   access_tier              = "Hot"
   enable_versioning        = true
+
+  network_rules = {
+    default_action = "Deny"
+    ip_rules       = []
+    bypass = [
+      "Logging",
+      "Metrics",
+      "AzureServices",
+    ]
+    virtual_network_subnet_ids = [
+      dependency.subnet_fn_admin.outputs.id,
+      dependency.subnet_fn_appasync.outputs.id,
+      dependency.subnet_fn_app1.outputs.id,
+      dependency.subnet_fn_app2.outputs.id,
+      dependency.subnet_fn_assets.outputs.id,
+      dependency.subnet_fn_public.outputs.id,
+      dependency.subnet_fn_services.outputs.id,
+      dependency.subnet_fn_services01.outputs.id,
+      dependency.subnet_fn_servicescache.outputs.id,
+    ]
+  }
 }

--- a/prod/westeurope/services/functions_services01_r3/subnet/terragrunt.hcl
+++ b/prod/westeurope/services/functions_services01_r3/subnet/terragrunt.hcl
@@ -30,6 +30,7 @@ inputs = {
 
   service_endpoints = [
     "Microsoft.Web",
-    "Microsoft.AzureCosmosDB"
+    "Microsoft.AzureCosmosDB",
+    "Microsoft.Storage",
   ]
 }


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

### List of changes

add firewall rules with whitelist resources
1. io-p-fn3-admin
2. io-p-fn3-app1
3. io-p-fn3-app2
4. io-p-fn3-appasync
5. io-p-fn3-assets
6. io-p-fn3-public
7. io-p-fn3-services
8. io-p-fn3-services01
9. io-p-fn3-servicescache

### Motivation and context

close iopstapi public access

### Type of changes

- [ ] Add new resources
- [x] Update configuration to existing resources
- [ ] Remove existing resources

### Does this introduce a change to production resources with possible user impact?

- [x] Yes, users may be impacted applying this change
- [ ] No

### Does this introduce an unwanted change on infrastructure? Check terraform plan execution result

- [ ] Yes
- [x] No

### Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->

---

### If PR is partially applied, why? (reserved to mantainers)

<!--- Describe the blocking cause -->
