### PR TITLE
[#IP-346] Update Node version for `appbackend`

### DIFF
--- a/prod/westeurope/linux/appbackendl1/app_service/terragrunt.hcl
+++ b/prod/westeurope/linux/appbackendl1/app_service/terragrunt.hcl
@@ -129,13 +129,12 @@ inputs = {
   client_cert_enabled = false
   https_only          = false
 
-  linux_fx_version = "NODE|10-lts"
+  linux_fx_version = "NODE|14-lts"
   app_command_line = "node /home/site/wwwroot/src/server.js"
 
   application_insights_instrumentation_key = dependency.application_insights.outputs.instrumentation_key
 
   app_settings = {
-    WEBSITE_NODE_DEFAULT_VERSION = "10.14.1"
     WEBSITE_RUN_FROM_PACKAGE     = "1"
 
     // ENVIRONMENT

--- a/prod/westeurope/linux/appbackendl1/app_service_slot_staging/terragrunt.hcl
+++ b/prod/westeurope/linux/appbackendl1/app_service_slot_staging/terragrunt.hcl
@@ -123,13 +123,12 @@ inputs = {
   client_cert_enabled = false
   https_only          = false
 
-  linux_fx_version = "NODE|10-lts"
+  linux_fx_version = "NODE|14-lts"
   app_command_line = "node /home/site/wwwroot/src/server.js"
 
   application_insights_instrumentation_key = dependency.application_insights.outputs.instrumentation_key
 
   app_settings = {
-    WEBSITE_NODE_DEFAULT_VERSION = "10.14.1"
     WEBSITE_RUN_FROM_PACKAGE     = "1"
 
     // ENVIRONMENT

--- a/prod/westeurope/linux/appbackendl2/app_service/terragrunt.hcl
+++ b/prod/westeurope/linux/appbackendl2/app_service/terragrunt.hcl
@@ -129,13 +129,12 @@ inputs = {
   client_cert_enabled = false
   https_only          = false
 
-  linux_fx_version = "NODE|10-lts"
+  linux_fx_version = "NODE|14-lts"
   app_command_line = "node /home/site/wwwroot/src/server.js"
 
   application_insights_instrumentation_key = dependency.application_insights.outputs.instrumentation_key
 
   app_settings = {
-    WEBSITE_NODE_DEFAULT_VERSION = "10.14.1"
     WEBSITE_RUN_FROM_PACKAGE     = "1"
 
     // ENVIRONMENT

--- a/prod/westeurope/linux/appbackendl2/app_service_slot_staging/terragrunt.hcl
+++ b/prod/westeurope/linux/appbackendl2/app_service_slot_staging/terragrunt.hcl
@@ -123,13 +123,12 @@ inputs = {
   client_cert_enabled = false
   https_only          = false
 
-  linux_fx_version = "NODE|10-lts"
+  linux_fx_version = "NODE|14-lts"
   app_command_line = "node /home/site/wwwroot/src/server.js"
 
   application_insights_instrumentation_key = dependency.application_insights.outputs.instrumentation_key
 
   app_settings = {
-    WEBSITE_NODE_DEFAULT_VERSION = "10.14.1"
     WEBSITE_RUN_FROM_PACKAGE     = "1"
 
     // ENVIRONMENT

--- a/prod/westeurope/linux/appbackendli/app_service/terragrunt.hcl
+++ b/prod/westeurope/linux/appbackendli/app_service/terragrunt.hcl
@@ -129,13 +129,12 @@ inputs = {
   client_cert_enabled = false
   https_only          = false
 
-  linux_fx_version = "NODE|10-lts"
+  linux_fx_version = "NODE|14-lts"
   app_command_line = "node /home/site/wwwroot/src/server.js"
 
   application_insights_instrumentation_key = dependency.application_insights.outputs.instrumentation_key
 
   app_settings = {
-    WEBSITE_NODE_DEFAULT_VERSION = "10.14.1"
     WEBSITE_RUN_FROM_PACKAGE     = "1"
 
     // ENVIRONMENT

--- a/prod/westeurope/linux/appbackendli/app_service_slot_staging/terragrunt.hcl
+++ b/prod/westeurope/linux/appbackendli/app_service_slot_staging/terragrunt.hcl
@@ -123,13 +123,12 @@ inputs = {
   client_cert_enabled = false
   https_only          = false
 
-  linux_fx_version = "NODE|10-lts"
+  linux_fx_version = "NODE|14-lts"
   app_command_line = "node /home/site/wwwroot/src/server.js"
 
   application_insights_instrumentation_key = dependency.application_insights.outputs.instrumentation_key
 
   app_settings = {
-    WEBSITE_NODE_DEFAULT_VERSION = "10.14.1"
     WEBSITE_RUN_FROM_PACKAGE     = "1"
 
     // ENVIRONMENT


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

### List of changes
<!--- Describe your changes in detail -->
* update `linux_fx_version` to `14-lts`
* remove useless `WEBSITE_NODE_DEFAULT_VERSION` app setting

### Motivation and context

<!--- Why is this change required? What problem does it solve? -->
We needed to upgrade Node runtime to the latest available version. Unfortunately, we found out **we cannot pin to a specific version**, but we must use what the app service is bound to (`14.15.1` at the time of writing).
Also, we removed `WEBSITE_NODE_DEFAULT_VERSION` as we understood it does not affect the runtime version.

### Type of changes

- [ ] Add new resources
- [x] Update configuration to existing resources
- [ ] Remove existing resources

### Does this introduce a change to production resources with possible user impact?

- [x] Yes, users may be impacted applying this change
- [ ] No

### Does this introduce an unwanted change on infrastructure? Check terraform plan execution result

- [ ] Yes
- [x] No

### Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->

---

### If PR is partially applied, why? (reserved to mantainers)

<!--- Describe the blocking cause -->
