### PR TITLE
[IOPAY] update csp to allow connection from uat PM env

### DIFF
--- a/prod/westeurope/common/cdn/cdn_endpoint_iopay/terragrunt.hcl
+++ b/prod/westeurope/common/cdn/cdn_endpoint_iopay/terragrunt.hcl
@@ -45,7 +45,12 @@ inputs = {
       {
         action = "Overwrite"
         name   = "Content-Security-Policy"
-        value  = "default-src 'self'; connect-src 'self' https://api.io.italia.it https://api-eu.mixpanel.com https://wisp2.pagopa.gov.it;"
+        value  = "default-src 'self'; connect-src 'self' https://api.io.italia.it https://api-eu.mixpanel.com https://wisp2.pagopa.gov.it"
+      },
+      {
+        action = "Append"
+        name   = "Content-Security-Policy"
+        value  = " https://acardste.vaservices.eu;"
       },
       {
         action = "Append"


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

### List of changes

- add UAT _Payment Manager_ host in io-pay _Content Security Policy_, in particulat in `connect-src`

### Motivation and context

The goal of this PR is to add the Payment Manager host into the Content Secury Policy of io-pay cdn, for testing purposes.

### Type of changes

- [ ] Add new resources
- [ ] Update configuration to existing resources
- [ ] Remove existing resources

### Does this introduce a change to production resources with possible user impact?

- [ ] Yes, users may be impacted applying this change
- [ ] No

### Does this introduce an unwanted change on infrastructure? Check terraform plan execution result

- [ ] Yes
- [ ] No

### Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->

---

### If PR is partially applied, why? (reserved to mantainers)

<!--- Describe the blocking cause -->
