### PR TITLE
[#IP-429] Add policy for hard delete user data blobs

### DIFF
--- a/prod/westeurope/internal/api/storage_user-data-download/account/terragrunt.hcl
+++ b/prod/westeurope/internal/api/storage_user-data-download/account/terragrunt.hcl
@@ -19,5 +19,4 @@ inputs = {
   account_tier                                 = "Standard"
   account_replication_type                     = "GRS"
   access_tier                                  = "Hot"
-  blob_properties_delete_retention_policy_days = 15
 }

--- a/prod/westeurope/internal/api/storage_user-data-download/management_policy/terragrunt.hcl
+++ b/prod/westeurope/internal/api/storage_user-data-download/management_policy/terragrunt.hcl
@@ -1,0 +1,36 @@
+# Internal
+dependency "storage_account" {
+  config_path = "../account"
+}
+
+# Include all settings from the root terragrunt.hcl file
+include {
+  path = find_in_parent_folders()
+}
+
+terraform {
+  source = "git::git@github.com:pagopa/io-infrastructure-modules-new.git//azurerm_storage_management_policy?ref=v3.0.3"
+}
+
+inputs = {
+  storage_account_id = dependency.storage_account.outputs.id
+
+  rules = [
+    {
+      name    = "deleteafter14days"
+      enabled = true
+      filters = {
+        prefix_match = []
+        blob_types   = ["blockBlob"]
+      }
+      actions = {
+        base_blob = {
+          tier_to_cool_after_days_since_modification_greater_than    = 0
+          tier_to_archive_after_days_since_modification_greater_than = 0
+          delete_after_days_since_modification_greater_than          = 14
+        }
+        snapshot = null
+      }
+    },
+  ]
+}

--- a/prod/westeurope/internal/api/storage_user-data-download/management_policy/terragrunt.hcl
+++ b/prod/westeurope/internal/api/storage_user-data-download/management_policy/terragrunt.hcl
@@ -3,6 +3,11 @@ dependency "storage_account" {
   config_path = "../account"
 }
 
+dependency "storage_container_user-data-download" {
+  config_path = "../container_user-data-download"
+}
+
+
 # Include all settings from the root terragrunt.hcl file
 include {
   path = find_in_parent_folders()
@@ -20,7 +25,7 @@ inputs = {
       name    = "deleteafter14days"
       enabled = true
       filters = {
-        prefix_match = []
+        prefix_match = [dependency.storage_container_user-data-download.outputs.name]
         blob_types   = ["blockBlob"]
       }
       actions = {


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

### List of changes

<!--- Describe your changes in detail -->
* add a retention policy of 14 days 
* remove previous configuration (not working)

### Motivation and context

<!--- Why is this change required? What problem does it solve? -->
Although we have a business rule for data portability bundle to be available for no longer that 14 days, we have evidence they are still reachable after such period.
The main cause seems to be the `blob_properties_delete_retention_policy_days` attribute not to work as intended (it should set a soft-delete retention policy).

As we have no actual need to recover such blobs after they're deleted, we can use a hard-delete policy, which is proven to work in many other scenarios we have.


### Type of changes

- [ ] Add new resources
- [x] Update configuration to existing resources
- [ ] Remove existing resources

### Does this introduce a change to production resources with possible user impact?

- [x] Yes, users may be impacted applying this change
- [ ] No

### Does this introduce an unwanted change on infrastructure? Check terraform plan execution result

- [ ] Yes
- [ ] No

### Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->

---

### If PR is partially applied, why? (reserved to mantainers)

<!--- Describe the blocking cause -->
