### PR TITLE
[IP-429] Use hard delete for user-data-download

### DIFF
--- a/prod/westeurope/internal/api/storage_user-data-download/management_policy/terragrunt.hcl
+++ b/prod/westeurope/internal/api/storage_user-data-download/management_policy/terragrunt.hcl
@@ -1,0 +1,36 @@
+# Internal
+dependency "storage_account" {
+  config_path = "../account"
+}
+
+# Include all settings from the root terragrunt.hcl file
+include {
+  path = find_in_parent_folders()
+}
+
+terraform {
+  source = "git::git@github.com:pagopa/io-infrastructure-modules-new.git//azurerm_storage_management_policy?ref=v3.0.3"
+}
+
+inputs = {
+  storage_account_id = dependency.storage_account.outputs.id
+
+  rules = [
+    {
+      name    = "deleteafter15days"
+      enabled = true
+      filters = {
+        prefix_match = ["user-data-download"]
+        blob_types   = ["blockBlob"]
+      }
+      actions = {
+        base_blob = {
+          tier_to_cool_after_days_since_modification_greater_than    = 0
+          tier_to_archive_after_days_since_modification_greater_than = 0
+          delete_after_days_since_modification_greater_than          = 15 # 15 days
+        }
+        snapshot = null
+      }
+    }
+  ]
+}


### PR DESCRIPTION
### List of changes

This PR is adding a azurerm_storage_management_policy to the userdatadownload storage account, to enforce a hard delete after 15 days. The management policy is filtering based on container type ("blob") and name ("user-data-download").

### Motivation and context

This PR fixes the bug reported in the IP-429 ticket.

### Type of changes

- [ ] Add new resources
- [x] Update configuration to existing resources
- [ ] Remove existing resources

### Does this introduce a change to production resources with possible user impact?

- [x] Yes, users may be impacted applying this change
- [ ] No

### Does this introduce an unwanted change on infrastructure? Check terraform plan execution result

- [ ] Yes
- [x] No
