### PR TITLE
[#ENTE-138] Add SERVICEID_EXCLUSION_LIST to service-cache

### DIFF
--- a/prod/westeurope/internal/api/functions_servicescache_r3/function_app/terragrunt.hcl
+++ b/prod/westeurope/internal/api/functions_servicescache_r3/function_app/terragrunt.hcl
@@ -101,8 +101,6 @@ inputs = {
 
     AssetsStorageConnection = dependency.storage_account_assets.outputs.primary_connection_string
 
-    SERVICEID_EXCLUSION_LIST   = "01DBJNFSJYB53TP0AZNA8FQGJJ,01EB8AXKNV6NMSP2R25KSGF743,01ERMMC1QXZWH05X4Y49JNKW2D,01EQXCQT6DR20N53MVHC3QTA78"
-
     // Disabled functions on slot function
     "AzureWebJobs.UpdateVisibleServicesCache.Disabled" = "0"
   }
@@ -110,6 +108,7 @@ inputs = {
   app_settings_secrets = {
     key_vault_id = dependency.key_vault.outputs.id
     map = {
+      SERVICEID_EXCLUSION_LIST = "io-fn-services-SERVICEID-EXCLUSION-LIST"
     }
   }
 


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

### List of changes
Add `SERVICEID_EXCLUSION_LIST` env variable to `io-functions-service-cache`

<!--- Describe your changes in detail -->

### Motivation and context
Some National services are displayed with the flag `in arrivo`. These services are included now into the ENV variable for the quality check exclusion list.
<!--- Why is this change required? What problem does it solve? -->

### Type of changes

- [ ] Add new resources
- [X] Update configuration to existing resources
- [ ] Remove existing resources

### Does this introduce a change to production resources with possible user impact?

- [ ] Yes, users may be impacted applying this change
- [ ] No

### Does this introduce an unwanted change on infrastructure? Check terraform plan execution result

- [ ] Yes
- [ ] No

### Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->

---

### If PR is partially applied, why? (reserved to mantainers)

<!--- Describe the blocking cause -->
