### PR TITLE
[INFRA-372] Add nat gateway for app backend

### DIFF
--- a/prod/westeurope/common/nat_gateway/terragrunt.hcl
+++ b/prod/westeurope/common/nat_gateway/terragrunt.hcl
@@ -10,6 +10,18 @@ dependency "subnet_cgn_merchant" {
   config_path = "../../cgn/functions_cgn_merchant/subnet"
 }
 
+dependency "subnet_appbackendl1" {
+  config_path = "../../linux/appbackendl1/subnet"
+}
+
+dependency "subnet_appbackendl2" {
+  config_path = "../../linux/appbackendl2/subnet"
+}
+
+dependency "subnet_appbackendli" {
+  config_path = "../../linux/appbackendli/subnet"
+}
+
 # Common
 dependency "resource_group" {
   config_path = "../resource_group"
@@ -31,6 +43,9 @@ inputs = {
     dependency.subnet_fneucovidcert.outputs.id,
     dependency.subnet_cgn.outputs.id,
     dependency.subnet_cgn_merchant.outputs.id,
+    dependency.subnet_appbackendl1.outputs.id,
+    dependency.subnet_appbackendl2.outputs.id,
+    dependency.subnet_appbackendli.outputs.id,
   ]
   location         = "westeurope"
   public_ips_count = 2

--- a/prod/westeurope/linux/appbackendl1/app_service/terragrunt.hcl
+++ b/prod/westeurope/linux/appbackendl1/app_service/terragrunt.hcl
@@ -132,7 +132,9 @@ inputs = {
   application_insights_instrumentation_key = dependency.application_insights.outputs.instrumentation_key
 
   app_settings = {
-    WEBSITE_RUN_FROM_PACKAGE     = "1"
+    WEBSITE_RUN_FROM_PACKAGE = "1"
+    WEBSITE_VNET_ROUTE_ALL   = "1"
+    WEBSITE_DNS_SERVER       = "168.63.129.16"
 
     // ENVIRONMENT
     NODE_ENV = "production"

--- a/prod/westeurope/linux/appbackendl1/app_service_slot_staging/terragrunt.hcl
+++ b/prod/westeurope/linux/appbackendl1/app_service_slot_staging/terragrunt.hcl
@@ -126,7 +126,9 @@ inputs = {
   application_insights_instrumentation_key = dependency.application_insights.outputs.instrumentation_key
 
   app_settings = {
-    WEBSITE_RUN_FROM_PACKAGE     = "1"
+    WEBSITE_RUN_FROM_PACKAGE = "1"
+    WEBSITE_VNET_ROUTE_ALL   = "1"
+    WEBSITE_DNS_SERVER       = "168.63.129.16"
 
     // ENVIRONMENT
     NODE_ENV = "production"

--- a/prod/westeurope/linux/appbackendl2/app_service/terragrunt.hcl
+++ b/prod/westeurope/linux/appbackendl2/app_service/terragrunt.hcl
@@ -132,7 +132,9 @@ inputs = {
   application_insights_instrumentation_key = dependency.application_insights.outputs.instrumentation_key
 
   app_settings = {
-    WEBSITE_RUN_FROM_PACKAGE     = "1"
+    WEBSITE_RUN_FROM_PACKAGE = "1"
+    WEBSITE_VNET_ROUTE_ALL   = "1"
+    WEBSITE_DNS_SERVER       = "168.63.129.16"
 
     // ENVIRONMENT
     NODE_ENV = "production"

--- a/prod/westeurope/linux/appbackendl2/app_service_slot_staging/terragrunt.hcl
+++ b/prod/westeurope/linux/appbackendl2/app_service_slot_staging/terragrunt.hcl
@@ -126,7 +126,9 @@ inputs = {
   application_insights_instrumentation_key = dependency.application_insights.outputs.instrumentation_key
 
   app_settings = {
-    WEBSITE_RUN_FROM_PACKAGE     = "1"
+    WEBSITE_RUN_FROM_PACKAGE = "1"
+    WEBSITE_VNET_ROUTE_ALL   = "1"
+    WEBSITE_DNS_SERVER       = "168.63.129.16"
 
     // ENVIRONMENT
     NODE_ENV = "production"

--- a/prod/westeurope/linux/appbackendli/app_service/terragrunt.hcl
+++ b/prod/westeurope/linux/appbackendli/app_service/terragrunt.hcl
@@ -131,7 +131,9 @@ inputs = {
   application_insights_instrumentation_key = dependency.application_insights.outputs.instrumentation_key
 
   app_settings = {
-    WEBSITE_RUN_FROM_PACKAGE     = "1"
+    WEBSITE_RUN_FROM_PACKAGE = "1"
+    WEBSITE_VNET_ROUTE_ALL   = "1"
+    WEBSITE_DNS_SERVER       = "168.63.129.16"
 
     // ENVIRONMENT
     NODE_ENV = "production"

--- a/prod/westeurope/linux/appbackendli/app_service_slot_staging/terragrunt.hcl
+++ b/prod/westeurope/linux/appbackendli/app_service_slot_staging/terragrunt.hcl
@@ -125,7 +125,9 @@ inputs = {
   application_insights_instrumentation_key = dependency.application_insights.outputs.instrumentation_key
 
   app_settings = {
-    WEBSITE_RUN_FROM_PACKAGE     = "1"
+    WEBSITE_RUN_FROM_PACKAGE = "1"
+    WEBSITE_VNET_ROUTE_ALL   = "1"
+    WEBSITE_DNS_SERVER       = "168.63.129.16"
 
     // ENVIRONMENT
     NODE_ENV = "production"


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

### List of changes

- add appbackend's subnets to nat gateway
- add `WEBSITE_VNET_ROUTE_ALL` and `WEBSITE_DNS_SERVER` to appbackends

### Motivation and context

use fixed outgoing ip for appbackends

### Type of changes

- [ ] Add new resources
- [x] Update configuration to existing resources
- [ ] Remove existing resources

### Does this introduce a change to production resources with possible user impact?

- [x] Yes, users may be impacted applying this change
- [ ] No

### Does this introduce an unwanted change on infrastructure? Check terraform plan execution result

- [ ] Yes
- [x] No

### Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->

---

### If PR is partially applied, why? (reserved to mantainers)

<!--- Describe the blocking cause -->
