### PR TITLE
[#ICC-101] add MIN_APP_VERSION_WITH_READ_AUTH to fn-services

### DIFF
--- a/prod/westeurope/internal/api/functions_services_r3/function_app/terragrunt.hcl
+++ b/prod/westeurope/internal/api/functions_services_r3/function_app/terragrunt.hcl
@@ -153,6 +153,12 @@ inputs = {
     OPT_OUT_EMAIL_SWITCH_DATE = local.opt_out_email_switch_date
     FF_OPT_IN_EMAIL_ENABLED   = local.ff_opt_in_email_enabled
 
+    // minimum app version that introduces read status opt-out
+    // NOTE: right now is set to a non existing version, since it's not yet deployed
+    // This way we can safely deploy fn-services without enabling ADVANCED functionalities
+    MIN_APP_VERSION_WITH_READ_AUTH = "10.0.0" 
+
+
     # this app settings is required to solve the issue:
     # https://github.com/terraform-providers/terraform-provider-azurerm/issues/10499
     WEBSITE_PROACTIVE_AUTOHEAL_ENABLED = "True"

--- a/prod/westeurope/internal/api/functions_services_r3/function_app_slot_staging/terragrunt.hcl
+++ b/prod/westeurope/internal/api/functions_services_r3/function_app_slot_staging/terragrunt.hcl
@@ -130,6 +130,12 @@ inputs = {
     OPT_OUT_EMAIL_SWITCH_DATE = local.opt_out_email_switch_date
     FF_OPT_IN_EMAIL_ENABLED   = local.ff_opt_in_email_enabled
 
+    // minimum app version that introduces read status opt-out
+    // NOTE: right now is set to a non existing version, since it's not yet deployed
+    // This way we can safely deploy fn-services without enabling ADVANCED functionalities
+    MIN_APP_VERSION_WITH_READ_AUTH = "10.0.0" 
+
+
     WEBSITE_PROACTIVE_AUTOHEAL_ENABLED = "True"
     # AzureFunctionsJobHost__extensions__durableTask__storageProvider__partitionCount = "16"
 


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

### List of changes

<!--- Describe your changes in detail -->

- add MIN_APP_VERSION_WITH_READ_AUTH variable

### Motivation and context

<!--- Why is this change required? What problem does it solve? -->

Allow fn-services to check user's app version with the minimum version that introduced the read status opt-out feature  

### Type of changes

- [ ] Add new resources
- [x] Update configuration to existing resources
- [ ] Remove existing resources

### Does this introduce a change to production resources with possible user impact?

- [ ] Yes, users may be impacted applying this change
- [ ] No

### Does this introduce an unwanted change on infrastructure? Check terraform plan execution result

- [ ] Yes
- [ ] No

### Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->

---

### If PR is partially applied, why? (reserved to mantainers)

<!--- Describe the blocking cause -->
