### PR TITLE
[#ICC-147] set MIN_APP_VERSION_WITH_READ_AUTH to 2.13.0

### DIFF
--- a/prod/westeurope/internal/api/functions_services_r3/function_app/terragrunt.hcl
+++ b/prod/westeurope/internal/api/functions_services_r3/function_app/terragrunt.hcl
@@ -156,7 +156,7 @@ inputs = {
     // minimum app version that introduces read status opt-out
     // NOTE: right now is set to a non existing version, since it's not yet deployed
     // This way we can safely deploy fn-services without enabling ADVANCED functionalities
-    MIN_APP_VERSION_WITH_READ_AUTH = "10.0.0" 
+    MIN_APP_VERSION_WITH_READ_AUTH = "2.13.0"
 
 
     # this app settings is required to solve the issue:

--- a/prod/westeurope/internal/api/functions_services_r3/function_app_slot_staging/terragrunt.hcl
+++ b/prod/westeurope/internal/api/functions_services_r3/function_app_slot_staging/terragrunt.hcl
@@ -133,7 +133,7 @@ inputs = {
     // minimum app version that introduces read status opt-out
     // NOTE: right now is set to a non existing version, since it's not yet deployed
     // This way we can safely deploy fn-services without enabling ADVANCED functionalities
-    MIN_APP_VERSION_WITH_READ_AUTH = "10.0.0" 
+    MIN_APP_VERSION_WITH_READ_AUTH = "2.13.0"
 
 
     WEBSITE_PROACTIVE_AUTOHEAL_ENABLED = "True"


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

### List of changes

<!--- Describe your changes in detail -->

- set MIN_APP_VERSION_WITH_READ_AUTH to 2.13.0

### Motivation and context

<!--- Why is this change required? What problem does it solve? -->

Set pivot version for enabling getMessage to return read status in case of advanced messages, if applicable

### Type of changes

- [ ] Add new resources
- [x] Update configuration to existing resources
- [ ] Remove existing resources

### Does this introduce a change to production resources with possible user impact?

- [ ] Yes, users may be impacted applying this change
- [ ] No

### Does this introduce an unwanted change on infrastructure? Check terraform plan execution result

- [ ] Yes
- [ ] No

### Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->

---

### If PR is partially applied, why? (reserved to mantainers)

<!--- Describe the blocking cause -->
