### PR TITLE
[#ICC-148] Add ApiMessageReadAdvanced and ApiMessageWriteAdvanced to APIM groups

### DIFF
--- a/prod/westeurope/internal/api/apim/api_management_groups/terragrunt.hcl
+++ b/prod/westeurope/internal/api/apim/api_management_groups/terragrunt.hcl
@@ -140,6 +140,18 @@ inputs = {
     {
       display_name = "ApiLegalMessageRead"
       name         = "apilegalmessageread"
+    },
+    {
+      display_name = "ApiMessageWriteAdvanced"
+      name         = "apimessagewriteadvanced"
+    },
+    {
+      display_name = "ApiMessageReadAdvanced"
+      name         = "apimessagereadadvanced"
+    },
+    {
+      display_name = "ApiThirdPartyMessageWrite"
+      name         = "apithirdpartymessagewrite"
     }
   ]
 }


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->
The new Read Status feature for Premium service will be controlled by 2 new APIM groups: only the service onboarded with the Premium contract will have those flags enabled.

### List of changes
<!--- Describe your changes in detail -->
Add ApiMessageReadAdvanced  to groups
Add ApiMessageWriteAdvanced to groups

### Motivation and context
<!--- Why is this change required? What problem does it solve? -->
Allow service to access to read status.

### Type of changes

- [ ] Add new resources
- [x] Update configuration to existing resources
- [ ] Remove existing resources

### Does this introduce a change to production resources with possible user impact?

- [ ] Yes, users may be impacted applying this change
- [x] No

### Does this introduce an unwanted change on infrastructure? Check terraform plan execution result

- [ ] Yes
- [ ] No

### Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->

---

### If PR is partially applied, why? (reserved to mantainers)

<!--- Describe the blocking cause -->
