### PR TITLE
[#ICC-103] Add APIM endpoint to connect to payment-updater

### DIFF
--- a/prod/westeurope/internal/api/apim/api_management_groups/terragrunt.hcl
+++ b/prod/westeurope/internal/api/apim/api_management_groups/terragrunt.hcl
@@ -140,6 +140,18 @@ inputs = {
     {
       display_name = "ApiLegalMessageRead"
       name         = "apilegalmessageread"
+    },
+    {
+      display_name = "ApiMessageWriteAdvanced"
+      name         = "apimessagewriteadvanced"
+    },
+    {
+      display_name = "ApiMessageReadAdvanced"
+      name         = "apimessagereadadvanced"
+    },
+    {
+      display_name = "ApiThirdPartyMessageWrite"
+      name         = "apithirdpartymessagewrite"
     }
   ]
 }

--- a/prod/westeurope/internal/api/functions_services_r3/function_app/terragrunt.hcl
+++ b/prod/westeurope/internal/api/functions_services_r3/function_app/terragrunt.hcl
@@ -145,6 +145,7 @@ inputs = {
     FETCH_KEEPALIVE_TIMEOUT             = "60000"
 
     IO_FUNCTIONS_ADMIN_BASE_URL       = "http://api-internal.io.italia.it"
+    APIM_BASE_URL                     = "http://api-internal.io.italia.it"
     DEFAULT_SUBSCRIPTION_PRODUCT_NAME = "io-services-api"
 
     // setting to true all the webhook message content will be disabled
@@ -183,6 +184,7 @@ inputs = {
       EMAIL_NOTIFICATION_SERVICE_BLACKLIST   = "io-EMAIL-SERVICE-BLACKLIST-ID"
       WEBHOOK_NOTIFICATION_SERVICE_BLACKLIST = "io-NOTIFICATION-SERVICE-BLACKLIST-ID"
       IO_FUNCTIONS_ADMIN_API_TOKEN           = "apim-IO-SERVICE-KEY"
+      APIM_SUBSCRIPTION_KEY                  = "apim-IO-SERVICE-KEY"
     }
   }
 

--- a/prod/westeurope/internal/api/functions_services_r3/function_app_slot_staging/terragrunt.hcl
+++ b/prod/westeurope/internal/api/functions_services_r3/function_app_slot_staging/terragrunt.hcl
@@ -122,6 +122,7 @@ inputs = {
     FETCH_KEEPALIVE_TIMEOUT             = "60000"
 
     IO_FUNCTIONS_ADMIN_BASE_URL       = "http://api-internal.io.italia.it"
+    APIM_BASE_URL                     = "http://api-internal.io.italia.it"
     DEFAULT_SUBSCRIPTION_PRODUCT_NAME = "io-services-api"
 
     // setting to true all the webhook message content will be disabled
@@ -158,6 +159,7 @@ inputs = {
       EMAIL_NOTIFICATION_SERVICE_BLACKLIST   = "io-EMAIL-SERVICE-BLACKLIST-ID"
       WEBHOOK_NOTIFICATION_SERVICE_BLACKLIST = "io-NOTIFICATION-SERVICE-BLACKLIST-ID"
       IO_FUNCTIONS_ADMIN_API_TOKEN           = "apim-IO-SERVICE-KEY"
+      APIM_SUBSCRIPTION_KEY                  = "apim-IO-SERVICE-KEY"
     }
   }
 


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->
Add variable configuration for APIM to connect to payment-update: it will allow to retrieve payment status in the GetMessage.

### List of changes

<!--- Describe your changes in detail -->
add apim url variable
add apim subscription for io-fn-service variable

### Motivation and context
Premium Service have to retrtieve also the payment status when retrieving a payment message

<!--- Why is this change required? What problem does it solve? -->

### Type of changes

- [ ] Add new resources
- [x] Update configuration to existing resources
- [ ] Remove existing resources

### Does this introduce a change to production resources with possible user impact?

- [ ] Yes, users may be impacted applying this change
- [x] No

### Does this introduce an unwanted change on infrastructure? Check terraform plan execution result

- [ ] Yes
- [ ] No

### Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->

---

### If PR is partially applied, why? (reserved to mantainers)

<!--- Describe the blocking cause -->
