### PR TITLE
[#IC-229] Set push via queue FF to "canary"

### DIFF
--- a/prod/westeurope/notifications/functions_pushnotif/function_app/terragrunt.hcl
+++ b/prod/westeurope/notifications/functions_pushnotif/function_app/terragrunt.hcl
@@ -157,7 +157,7 @@ inputs = {
 
     # Possible values : "none" | "all" | "beta" | "canary"
     NH_PARTITION_FEATURE_FLAG            = "all"
-    NOTIFY_VIA_QUEUE_FEATURE_FLAG        = "beta"
+    NOTIFY_VIA_QUEUE_FEATURE_FLAG        = "canary"
     BETA_USERS_STORAGE_CONNECTION_STRING = dependency.storage_beta_test_users.outputs.primary_connection_string
     BETA_USERS_TABLE_NAME                = dependency.storage_beta_test_users_table_notificationhub.outputs.name
 


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->
Set the Feature Flag to push the notification usign the storage queue to "canary". This will enable the new push implementation for the users usually used as first-adopters.

### List of changes
set the FF to canary
<!--- Describe your changes in detail -->

### Motivation and context
Gradually release the new phs implementations, in order to not impact all the users in case of bug.
<!--- Why is this change required? What problem does it solve? -->

### Type of changes

- [ ] Add new resources
- [x] Update configuration to existing resources
- [ ] Remove existing resources

### Does this introduce a change to production resources with possible user impact?

- [x] Yes, users may be impacted applying this change
- [ ] No

### Does this introduce an unwanted change on infrastructure? Check terraform plan execution result

- [ ] Yes
- [ ] No

### Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->

---

### If PR is partially applied, why? (reserved to mantainers)

<!--- Describe the blocking cause -->
