### PR TITLE
Add ttl for messages

### DIFF
--- a/prod/westeurope/internal/api/cosmosdb/container_message-status/terragrunt.hcl
+++ b/prod/westeurope/internal/api/cosmosdb/container_message-status/terragrunt.hcl
@@ -26,6 +26,7 @@ inputs = {
   account_name        = dependency.cosmosdb_account.outputs.name
   database_name       = dependency.cosmosdb_database.outputs.name
   partition_key_path  = "/messageId"
+  default_ttl = -1
 
   autoscale_settings = {
     max_throughput = 10000

--- a/prod/westeurope/internal/api/cosmosdb/container_messages/terragrunt.hcl
+++ b/prod/westeurope/internal/api/cosmosdb/container_messages/terragrunt.hcl
@@ -26,6 +26,7 @@ inputs = {
   account_name        = dependency.cosmosdb_account.outputs.name
   database_name       = dependency.cosmosdb_database.outputs.name
   partition_key_path  = "/fiscalCode"
+  default_ttl = -1
   
   autoscale_settings = {
     max_throughput = 14000

--- a/prod/westeurope/internal/api/functions_services_r3/function_app/terragrunt.hcl
+++ b/prod/westeurope/internal/api/functions_services_r3/function_app/terragrunt.hcl
@@ -175,6 +175,9 @@ inputs = {
     "AzureWebJobs.OnFailedProcessMessage.Disabled" = "0"
     "AzureWebJobs.ProcessMessage.Disabled"         = "0"
     "AzureWebJobs.WebhookNotification.Disabled"    = "0"
+
+    // the duration of message and message-status for those messages sent to user not registered on IO.
+    TTL_FOR_USER_NOT_FOUND = 94670856 //3 years in seconds
   }
 
   app_settings_secrets = {

--- a/prod/westeurope/internal/api/functions_services_r3/function_app_slot_staging/terragrunt.hcl
+++ b/prod/westeurope/internal/api/functions_services_r3/function_app_slot_staging/terragrunt.hcl
@@ -150,6 +150,9 @@ inputs = {
     "AzureWebJobs.OnFailedProcessMessage.Disabled" = "1"
     "AzureWebJobs.ProcessMessage.Disabled"         = "1"
     "AzureWebJobs.WebhookNotification.Disabled"    = "1"
+
+    // the duration of message and message-status for those messages sent to user not registered on IO.
+    TTL_FOR_USER_NOT_FOUND = 94670856 //3 years in seconds
   }
 
   app_settings_secrets = {


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

### List of changes

<!--- Describe your changes in detail -->
* Add ttl value in `functions_services_r3`
### Motivation and context
In order to set the `ttl` to the value of 3 years for `message` and `message-status` for those messages sent to users that are not found, we want to add this value in settings.

<!--- Why is this change required? What problem does it solve? -->

### Type of changes

- [ ] Add new resources
- [ ] Update configuration to existing resources
- [ ] Remove existing resources

### Does this introduce a change to production resources with possible user impact?

- [ ] Yes, users may be impacted applying this change
- [ ] No

### Does this introduce an unwanted change on infrastructure? Check terraform plan execution result

- [ ] Yes
- [ ] No

### Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->

---

### If PR is partially applied, why? (reserved to mantainers)

<!--- Describe the blocking cause -->
